### PR TITLE
feat: 引入问答意图前置拦截与查询构建重构

### DIFF
--- a/application/src/main/java/com/novel/splitter/application/service/rag/RagService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/rag/RagService.java
@@ -4,13 +4,16 @@ import com.novel.splitter.application.config.AppConfig;
 import com.novel.splitter.assembler.api.ContextAssembler;
 import com.novel.splitter.assembler.config.AssemblerConfig;
 import com.novel.splitter.domain.model.Answer;
+import com.novel.splitter.domain.model.AnswerType;
 import com.novel.splitter.domain.model.ContextBlock;
 import com.novel.splitter.domain.model.Prompt;
 import com.novel.splitter.domain.model.Scene;
 import com.novel.splitter.domain.model.dto.RagDebugResponse;
 import com.novel.splitter.domain.model.dto.RagRequest;
 import com.novel.splitter.domain.model.dto.RetrievalQuery;
+import com.novel.splitter.retrieval.api.AnswerPolicyClassifier;
 import com.novel.splitter.retrieval.api.RetrievalService;
+import com.novel.splitter.retrieval.impl.RetrievalQueryBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,6 +41,8 @@ public class RagService {
     private final ContextAssembler contextAssembler;
     private final AppConfig appConfig;
     private final AssemblerConfig assemblerConfig;
+    private final AnswerPolicyClassifier policyClassifier;
+    private final RetrievalQueryBuilder queryBuilder;
 
     /**
      * 提出问题并获取回答 (兼容旧接口)
@@ -64,6 +69,15 @@ public class RagService {
         StopWatch stopWatch = new StopWatch("RAG Debug");
         Map<String, Object> stats = new HashMap<>();
 
+        // 0. 前置意图拦截
+        AnswerType answerType = policyClassifier.classify(question);
+        if (answerType == AnswerType.UNSUPPORTED) {
+            log.info("Preview blocked by policy classifier: {}", question);
+            return RagDebugResponse.builder()
+                    .stats(Map.of("error", "问题不受支持：作为一个小说阅读助手，我只能回答与小说内容相关的问题。"))
+                    .build();
+        }
+
         try {
             // 1. 检索 (Retrieval)
             stopWatch.start("1. Retrieval");
@@ -76,12 +90,13 @@ public class RagService {
                 novelId = novel.replace(".txt", "");
             }
 
-            RetrievalQuery query = RetrievalQuery.builder()
-                    .question(question)
-                    .topK(actualTopK)
-                    .novel(novelId)
-                    .version(version)
-                    .build();
+            // 使用 QueryBuilder 增强查询
+            int currentChapter = -1; // 暂无当前阅读章节信息
+            RetrievalQuery query = queryBuilder.build(question, currentChapter);
+            query.setTopK(actualTopK);
+            query.setNovel(novelId);
+            query.setVersion(version);
+
             List<Scene> scenes = retrievalService.retrieve(query);
             stopWatch.stop();
             stats.put("retrievalTimeMs", stopWatch.getLastTaskTimeMillis());
@@ -137,6 +152,17 @@ public class RagService {
         
         log.info("Processing RAG request: query='{}', topK={}, novel={}, version={}", question, topK, novel, version);
 
+        // 0. 前置意图拦截
+        AnswerType answerType = policyClassifier.classify(question);
+        if (answerType == AnswerType.UNSUPPORTED) {
+            log.info("Question blocked by policy classifier: {}", question);
+            return Answer.builder()
+                    .answer("作为一个小说阅读助手，我只能回答与小说内容相关的问题哦。")
+                    .citations(Collections.emptyList())
+                    .confidence(1.0)
+                    .build();
+        }
+
         try {
             // 1. 检索 (Retrieval)
             stopWatch.start("1. Retrieval");
@@ -149,12 +175,13 @@ public class RagService {
                 novelId = novel.replace(".txt", "");
             }
 
-            RetrievalQuery query = RetrievalQuery.builder()
-                    .question(question)
-                    .topK(actualTopK)
-                    .novel(novelId)
-                    .version(version)
-                    .build();
+            // 使用 QueryBuilder 增强查询
+            int currentChapter = -1; // 暂无当前阅读章节信息
+            RetrievalQuery query = queryBuilder.build(question, currentChapter);
+            query.setTopK(actualTopK);
+            query.setNovel(novelId);
+            query.setVersion(version);
+
             List<Scene> scenes = retrievalService.retrieve(query);
             stopWatch.stop();
             log.info("Retrieved {} scenes", scenes.size());

--- a/retrieval/src/main/java/com/novel/splitter/retrieval/impl/RetrievalQueryBuilder.java
+++ b/retrieval/src/main/java/com/novel/splitter/retrieval/impl/RetrievalQueryBuilder.java
@@ -13,51 +13,53 @@ import org.springframework.stereotype.Component;
 @Component
 public class RetrievalQueryBuilder {
 
+    private static final String LAST_CHAPTER = "上一章";
+    private static final String CURRENT_CHAPTER = "这一章";
+    private static final String DIALOGUE_INTENT = "他说了什么";
+
     /**
-     * 构建查询对象
-     *
-     * @param question       用户自然语言问题
-     * @param currentChapter 当前阅读的章节号
-     * @return 结构化的 RetrievalQuery
+     * 构建查询对象（增强健壮性 + 语义清晰）
      */
     public RetrievalQuery build(String question, int currentChapter) {
-        if (question == null) {
-            throw new IllegalArgumentException("Question cannot be null");
+        if (question == null || question.isBlank()) {
+            throw new IllegalArgumentException("Question cannot be null or blank");
         }
 
         RetrievalQuery.RetrievalQueryBuilder builder = RetrievalQuery.builder()
-                .question(question);
+                .question(question.trim());
 
-        // 1. 解析章节范围 (Chapter Range)
         parseChapterRange(builder, question, currentChapter);
-
-        // 2. 解析角色/功能 (Role)
         parseRole(builder, question);
 
         return builder.build();
     }
 
-    private void parseChapterRange(RetrievalQuery.RetrievalQueryBuilder builder, String question, int currentChapter) {
-        if (question.contains("上一章")) {
-            // “上一章” → chapterFrom = current - 1
-            // 注意：如果当前是第1章，上一章可能是0或者无，这里简单处理为 current - 1
-            int target = Math.max(0, currentChapter - 1);
+    private void parseChapterRange(RetrievalQuery.RetrievalQueryBuilder builder,
+                                   String question,
+                                   int currentChapter) {
+        if (currentChapter <= 0) {
+            builder.chapterFrom(null);
+            builder.chapterTo(null);
+            return;
+        }
+
+        if (question.contains(LAST_CHAPTER)) {
+            int target = Math.max(1, currentChapter - 1);
             builder.chapterFrom(target);
-            builder.chapterTo(target); // 通常指“那一章”，所以是点查
-        } else if (question.contains("这一章")) {
-            // “这一章” → chapterFrom = chapterTo = current
+            builder.chapterTo(target);
+        }
+        else if (question.contains(CURRENT_CHAPTER)) {
             builder.chapterFrom(currentChapter);
             builder.chapterTo(currentChapter);
-        } else {
-            // 无法确定范围时，必须显式设置为 null
+        }
+        else {
             builder.chapterFrom(null);
             builder.chapterTo(null);
         }
     }
 
     private void parseRole(RetrievalQuery.RetrievalQueryBuilder builder, String question) {
-        if (question.contains("他说了什么")) {
-            // “他说了什么” → role = dialogue
+        if (question.contains(DIALOGUE_INTENT)) {
             builder.role("dialogue");
         } else {
             builder.role(null);

--- a/retrieval/src/main/java/com/novel/splitter/retrieval/impl/RuleBasedPolicyClassifier.java
+++ b/retrieval/src/main/java/com/novel/splitter/retrieval/impl/RuleBasedPolicyClassifier.java
@@ -10,21 +10,22 @@ import java.util.Set;
 @Component
 public class RuleBasedPolicyClassifier implements AnswerPolicyClassifier {
 
-    // Keywords that indicate the question is out of scope for a novel RAG system
     private static final Set<String> UNSUPPORTED_KEYWORDS = Set.of(
-        "写代码", "编程", "java", "python", "c++", 
-        "天气", "股票", "汇率", 
-        "现实", "今天", "新闻", 
-        "哈利波特", "三体", "金庸", // Cross-novel comparisons might be unsupported initially
-        "翻译", "英语", "总结全文"
+        "写代码", "编程", "java", "python", "c++",
+        "天气", "股票", "汇率", "新闻",
+        "现实", "今天", "翻译", "英语", "总结全文",
+        "哈利波特", "三体", "金庸"
     );
 
     private static final List<String> CHARACTER_KEYWORDS = List.of(
-        "谁", "关系", "性格", "外貌", "长相", "身份", "父亲", "母亲", "师傅", "徒弟", "主角", "配角", "妻子", "丈夫", "兄弟", "姐妹"
+        "谁", "关系", "性格", "外貌", "长相", "身份",
+        "父亲", "母亲", "师傅", "徒弟", "主角", "配角",
+        "妻子", "丈夫", "兄弟", "姐妹"
     );
 
     private static final List<String> TIMELINE_KEYWORDS = List.of(
-        "什么时候", "时间", "多久", "哪一年", "何时", "几点", "年代", "岁月", "之前", "之后", "顺序", "先", "后"
+        "什么时候", "时间", "多久", "哪一年", "何时",
+        "几点", "年代", "岁月", "之前", "之后", "顺序", "先", "后"
     );
 
     private static final List<String> LOCATION_KEYWORDS = List.of(
@@ -36,38 +37,26 @@ public class RuleBasedPolicyClassifier implements AnswerPolicyClassifier {
         if (question == null || question.isBlank()) {
             return AnswerType.UNSUPPORTED;
         }
-        
+
         String q = question.toLowerCase().trim();
 
-        // 1. UNSUPPORTED Check (Highest Priority)
-        for (String keyword : UNSUPPORTED_KEYWORDS) {
-            if (q.contains(keyword)) {
-                return AnswerType.UNSUPPORTED;
-            }
-        }
-        
-        // 2. CHARACTER Check
-        for (String keyword : CHARACTER_KEYWORDS) {
-            if (q.contains(keyword)) {
-                return AnswerType.CHARACTER;
-            }
+        // 最高优先级：域外问题直接拦截
+        if (UNSUPPORTED_KEYWORDS.stream().anyMatch(q::contains)) {
+            return AnswerType.UNSUPPORTED;
         }
 
-        // 3. TIMELINE Check
-        for (String keyword : TIMELINE_KEYWORDS) {
-            if (q.contains(keyword)) {
-                return AnswerType.TIMELINE;
-            }
+        // 意图匹配
+        if (CHARACTER_KEYWORDS.stream().anyMatch(q::contains)) {
+            return AnswerType.CHARACTER;
+        }
+        if (TIMELINE_KEYWORDS.stream().anyMatch(q::contains)) {
+            return AnswerType.TIMELINE;
+        }
+        if (LOCATION_KEYWORDS.stream().anyMatch(q::contains)) {
+            return AnswerType.LOCATION;
         }
 
-        // 4. LOCATION Check
-        for (String keyword : LOCATION_KEYWORDS) {
-            if (q.contains(keyword)) {
-                return AnswerType.LOCATION;
-            }
-        }
-
-        // 5. Default to FACT
+        // 默认：事实类问题
         return AnswerType.FACT;
     }
 }


### PR DESCRIPTION
## 🎯 Changes

### 1. 问答意图前置拦截机制
- 在 `RagService.java` 中引入 `AnswerPolicyClassifier` 和 `RetrievalQueryBuilder` 依赖。
- 在问答方法中新增前置意图拦截逻辑，用于识别并拒绝回答与小说内容无关的问题。
- 使用 `queryBuilder` 替换了直接构建 `RetrievalQuery` 对象的逻辑，增强了查询构建的灵活性和可维护性。

### 2. 查询构建逻辑重构
- 在 `RetrievalQueryBuilder.java` 中将硬编码的中文提示字符串提取为静态常量，提升了代码的可读性和可维护性。
- 增加了对传入问题为空或空白字符的异常校验，增强了系统的健壮性。
- 优化了章节范围解析逻辑，增加了对无效当前章节号的边界处理，避免潜在的运行时错误。

### 3. 分类器代码优化
- 在 `RuleBasedPolicyClassifier.java` 中重新格式化了各类意图匹配关键词的集合声明代码，使其更清晰。
- 使用 Java Stream API 替换了原有的 for 循环匹配逻辑，提高了代码的简洁性和执行效率。
- 移除了代码中的冗余注释并精简了整体分类逻辑，提升了代码的可读性。

## 💡 Technical Highlights

- **意图前置拦截**: 通过 `AnswerPolicyClassifier` 在RAG流程早期拦截非小说相关问题，减少不必要的检索和生成开销。
- **策略模式**: `AnswerPolicyClassifier` 的引入为未来扩展更多意图识别策略提供了良好的扩展点。
- **代码可维护性**: 通过常量替换硬编码和 Stream API 优化循环，显著提升了分类器和查询构建模块的可维护性。
- **系统健壮性**: 增加了对输入参数的校验和边界处理，有效防止了因异常输入导致的系统错误。