### PR TITLE
refactor: 统一后端API响应并增强前端Axios拦截器

### DIFF
--- a/application/src/main/java/com/novel/splitter/application/controller/ChromaManagementController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/ChromaManagementController.java
@@ -4,7 +4,6 @@ import com.novel.splitter.application.service.chroma.ChromaAdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -31,7 +30,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "获取Chroma统计信息", description = "获取当前Chroma数据库中的向量总数及存储类型")
     @GetMapping("/stats")
-    public ResponseEntity<Map<String, Object>> getStats() {
+    public Map<String, Object> getStats() {
         return chromaAdminService.getStats();
     }
 
@@ -42,7 +41,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "重置Chroma数据库", description = "清空Chroma数据库中的所有向量数据")
     @PostMapping("/reset")
-    public ResponseEntity<Map<String, String>> reset() {
+    public Map<String, String> reset() {
         return chromaAdminService.reset();
     }
 
@@ -54,7 +53,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "删除Chroma文档", description = "根据指定的过滤条件删除Chroma数据库中的文档记录")
     @PostMapping("/delete")
-    public ResponseEntity<Map<String, String>> delete(@RequestBody Map<String, Object> filter) {
+    public Map<String, String> delete(@RequestBody Map<String, Object> filter) {
         return chromaAdminService.delete(filter);
     }
     
@@ -63,7 +62,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "获取Chroma健康状态", description = "获取Chroma服务器的健康检查结果")
     @GetMapping("/healthcheck")
-    public ResponseEntity<Map<String, Object>> healthcheck() {
+    public Map<String, Object> healthcheck() {
         return chromaAdminService.healthcheck();
     }
 
@@ -72,7 +71,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "获取Chroma版本", description = "获取当前Chroma服务器的版本号")
     @GetMapping("/version")
-    public ResponseEntity<Map<String, String>> version() {
+    public Map<String, String> version() {
         return chromaAdminService.version();
     }
 
@@ -81,7 +80,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "获取Chroma心跳", description = "获取Chroma服务器的心跳时间戳")
     @GetMapping("/heartbeat")
-    public ResponseEntity<Map<String, Object>> heartbeat() {
+    public Map<String, Object> heartbeat() {
         return chromaAdminService.heartbeat();
     }
 
@@ -90,7 +89,7 @@ public class ChromaManagementController {
      */
     @Operation(summary = "获取所有集合", description = "获取默认租户和数据库下的所有Chroma集合")
     @GetMapping("/collections")
-    public ResponseEntity<?> getCollections() {
+    public Object getCollections() {
         return chromaAdminService.proxyGet("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections");
     }
 
@@ -98,13 +97,13 @@ public class ChromaManagementController {
 
     @Operation(summary = "预检检查", description = "获取Chroma的预检检查状态")
     @GetMapping("/pre-flight-checks")
-    public ResponseEntity<?> preFlightChecks() {
+    public Object preFlightChecks() {
         return chromaAdminService.proxyGet("/api/v2/pre-flight-checks");
     }
 
     @Operation(summary = "认证身份", description = "获取当前认证的身份信息")
     @GetMapping("/auth/identity")
-    public ResponseEntity<?> authIdentity() {
+    public Object authIdentity() {
         return chromaAdminService.proxyGet("/api/v2/auth/identity");
     }
 
@@ -112,19 +111,19 @@ public class ChromaManagementController {
 
     @Operation(summary = "获取租户列表", description = "获取所有租户信息")
     @GetMapping("/tenants")
-    public ResponseEntity<?> getTenants() {
+    public Object getTenants() {
         return chromaAdminService.proxyGet("/api/v2/tenants");
     }
 
     @Operation(summary = "创建租户", description = "创建新的租户")
     @PostMapping("/tenants")
-    public ResponseEntity<?> createTenant(@RequestBody Object body) {
+    public Object createTenant(@RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants", body);
     }
 
     @Operation(summary = "更新租户", description = "更新指定租户")
     @PatchMapping("/tenants/{name}")
-    public ResponseEntity<?> updateTenant(@PathVariable String name, @RequestBody Object body) {
+    public Object updateTenant(@PathVariable String name, @RequestBody Object body) {
         return chromaAdminService.proxyPatch("/api/v2/tenants/" + name, body);
     }
 
@@ -132,25 +131,25 @@ public class ChromaManagementController {
 
     @Operation(summary = "获取数据库列表", description = "获取指定租户下的所有数据库")
     @GetMapping("/tenants/{t}/databases")
-    public ResponseEntity<?> getDatabases(@PathVariable String t) {
+    public Object getDatabases(@PathVariable String t) {
         return chromaAdminService.proxyGet("/api/v2/tenants/" + t + "/databases");
     }
 
     @Operation(summary = "创建数据库", description = "在指定租户下创建新的数据库")
     @PostMapping("/tenants/{t}/databases")
-    public ResponseEntity<?> createDatabase(@PathVariable String t, @RequestBody Object body) {
+    public Object createDatabase(@PathVariable String t, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + t + "/databases", body);
     }
 
     @Operation(summary = "获取数据库详情", description = "获取指定租户下的数据库详情")
     @GetMapping("/tenants/{t}/databases/{d}")
-    public ResponseEntity<?> getDatabase(@PathVariable String t, @PathVariable String d) {
+    public Object getDatabase(@PathVariable String t, @PathVariable String d) {
         return chromaAdminService.proxyGet("/api/v2/tenants/" + t + "/databases/" + d);
     }
 
     @Operation(summary = "删除数据库", description = "删除指定租户下的数据库")
     @DeleteMapping("/tenants/{t}/databases/{d}")
-    public ResponseEntity<?> deleteDatabase(@PathVariable String t, @PathVariable String d) {
+    public Object deleteDatabase(@PathVariable String t, @PathVariable String d) {
         return chromaAdminService.proxyDelete("/api/v2/tenants/" + t + "/databases/" + d);
     }
 
@@ -158,25 +157,25 @@ public class ChromaManagementController {
 
     @Operation(summary = "创建集合", description = "在默认租户和数据库下创建新集合")
     @PostMapping("/collections")
-    public ResponseEntity<?> createCollection(@RequestBody Object body) {
+    public Object createCollection(@RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections", body);
     }
 
     @Operation(summary = "获取集合详情", description = "获取指定集合的详细信息")
     @GetMapping("/collections/{id}")
-    public ResponseEntity<?> getCollection(@PathVariable String id) {
+    public Object getCollection(@PathVariable String id) {
         return chromaAdminService.proxyGet("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id);
     }
 
     @Operation(summary = "更新集合", description = "更新指定集合的信息")
     @PutMapping("/collections/{id}")
-    public ResponseEntity<?> updateCollection(@PathVariable String id, @RequestBody Object body) {
+    public Object updateCollection(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPut("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id, body);
     }
 
     @Operation(summary = "删除集合", description = "删除指定集合")
     @DeleteMapping("/collections/{id}")
-    public ResponseEntity<?> deleteCollection(@PathVariable String id) {
+    public Object deleteCollection(@PathVariable String id) {
         return chromaAdminService.proxyDelete("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id);
     }
 
@@ -184,43 +183,43 @@ public class ChromaManagementController {
 
     @Operation(summary = "添加文档", description = "向指定集合添加文档")
     @PostMapping("/collections/{id}/add")
-    public ResponseEntity<?> addDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object addDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/add", body);
     }
 
     @Operation(summary = "更新或插入文档", description = "向指定集合更新或插入文档")
     @PostMapping("/collections/{id}/upsert")
-    public ResponseEntity<?> upsertDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object upsertDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/upsert", body);
     }
 
     @Operation(summary = "更新文档", description = "更新指定集合中的文档")
     @PostMapping("/collections/{id}/update")
-    public ResponseEntity<?> updateDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object updateDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/update", body);
     }
 
     @Operation(summary = "删除文档", description = "从指定集合中删除文档")
     @PostMapping("/collections/{id}/delete")
-    public ResponseEntity<?> deleteDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object deleteDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/delete", body);
     }
 
     @Operation(summary = "获取文档", description = "从指定集合中获取文档")
     @PostMapping("/collections/{id}/get")
-    public ResponseEntity<?> getDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object getDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/get", body);
     }
 
     @Operation(summary = "查询文档", description = "在指定集合中查询文档")
     @PostMapping("/collections/{id}/query")
-    public ResponseEntity<?> queryDocuments(@PathVariable String id, @RequestBody Object body) {
+    public Object queryDocuments(@PathVariable String id, @RequestBody Object body) {
         return chromaAdminService.proxyPost("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/query", body);
     }
 
     @Operation(summary = "统计文档数", description = "获取指定集合的文档总数")
     @GetMapping("/collections/{id}/count")
-    public ResponseEntity<?> countDocuments(@PathVariable String id) {
+    public Object countDocuments(@PathVariable String id) {
         return chromaAdminService.proxyGet("/api/v2/tenants/" + DEFAULT_TENANT + "/databases/" + DEFAULT_DATABASE + "/collections/" + id + "/count");
     }
 }

--- a/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminService.java
@@ -1,30 +1,28 @@
 package com.novel.splitter.application.service.chroma;
 
-import org.springframework.http.ResponseEntity;
-
 import java.util.Map;
 
 public interface ChromaAdminService {
 
-    ResponseEntity<Map<String, Object>> getStats();
+    Map<String, Object> getStats();
 
-    ResponseEntity<Map<String, String>> reset();
+    Map<String, String> reset();
 
-    ResponseEntity<Map<String, String>> delete(Map<String, Object> filter);
+    Map<String, String> delete(Map<String, Object> filter);
 
-    ResponseEntity<Map<String, Object>> healthcheck();
+    Map<String, Object> healthcheck();
 
-    ResponseEntity<Map<String, String>> version();
+    Map<String, String> version();
 
-    ResponseEntity<Map<String, Object>> heartbeat();
+    Map<String, Object> heartbeat();
 
-    ResponseEntity<?> proxyGet(String path);
+    Object proxyGet(String path);
 
-    ResponseEntity<?> proxyPost(String path, Object body);
+    Object proxyPost(String path, Object body);
 
-    ResponseEntity<?> proxyPut(String path, Object body);
+    Object proxyPut(String path, Object body);
 
-    ResponseEntity<?> proxyPatch(String path, Object body);
+    Object proxyPatch(String path, Object body);
 
-    ResponseEntity<?> proxyDelete(String path);
+    Object proxyDelete(String path);
 }

--- a/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
@@ -17,99 +17,106 @@ public class ChromaAdminServiceImpl implements ChromaAdminService {
     private final ChromaApiClient chromaApiClient;
 
     @Override
-    public ResponseEntity<Map<String, Object>> getStats() {
+    public Map<String, Object> getStats() {
         try {
             long count = vectorStore.count();
-            return ResponseEntity.ok(Map.of(
+            return Map.of(
                     "count", count,
                     "storeType", vectorStore.getClass().getSimpleName()
-            ));
+            );
         } catch (Exception e) {
             log.error("获取Chroma统计信息失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            throw new RuntimeException("获取Chroma统计信息失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<Map<String, String>> reset() {
+    public Map<String, String> reset() {
         try {
             vectorStore.reset();
-            return ResponseEntity.ok(Map.of("message", "Database reset successfully"));
+            return Map.of("message", "Database reset successfully");
         } catch (Exception e) {
             log.error("重置Chroma数据库失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            throw new RuntimeException("重置Chroma数据库失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<Map<String, String>> delete(Map<String, Object> filter) {
+    public Map<String, String> delete(Map<String, Object> filter) {
         try {
             if (filter == null || filter.isEmpty()) {
-                return ResponseEntity.badRequest().body(Map.of("error", "Filter cannot be empty"));
+                throw new IllegalArgumentException("Filter cannot be empty");
             }
             vectorStore.delete(filter);
-            return ResponseEntity.ok(Map.of("message", "Documents deleted successfully"));
+            return Map.of("message", "Documents deleted successfully");
+        } catch (IllegalArgumentException e) {
+            throw e;
         } catch (Exception e) {
             log.error("删除Chroma文档失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            throw new RuntimeException("删除Chroma文档失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<Map<String, Object>> healthcheck() {
+    public Map<String, Object> healthcheck() {
         try {
-            Map<String, Object> response = chromaApiClient.getMap("/api/v2/healthcheck");
-            return ResponseEntity.ok(response);
+            return chromaApiClient.getMap("/api/v2/healthcheck");
         } catch (Exception e) {
             log.error("获取Chroma健康状态失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage(), "status", "down"));
+            throw new RuntimeException("获取Chroma健康状态失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<Map<String, String>> version() {
+    public Map<String, String> version() {
         try {
             String version = chromaApiClient.getString("/api/v2/version");
-            return ResponseEntity.ok(Map.of("version", version != null ? version.replace("\"", "") : "unknown"));
+            return Map.of("version", version != null ? version.replace("\"", "") : "unknown");
         } catch (Exception e) {
             log.error("获取Chroma版本失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            throw new RuntimeException("获取Chroma版本失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<Map<String, Object>> heartbeat() {
+    public Map<String, Object> heartbeat() {
         try {
-            Map<String, Object> response = chromaApiClient.getMap("/api/v2/heartbeat");
-            return ResponseEntity.ok(response);
+            return chromaApiClient.getMap("/api/v2/heartbeat");
         } catch (Exception e) {
             log.error("获取Chroma心跳失败", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            throw new RuntimeException("获取Chroma心跳失败: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public ResponseEntity<?> proxyGet(String path) {
-        return chromaApiClient.get(path);
+    public Object proxyGet(String path) {
+        return extractBody(chromaApiClient.get(path));
     }
 
     @Override
-    public ResponseEntity<?> proxyPost(String path, Object body) {
-        return chromaApiClient.post(path, body);
+    public Object proxyPost(String path, Object body) {
+        return extractBody(chromaApiClient.post(path, body));
     }
 
     @Override
-    public ResponseEntity<?> proxyPut(String path, Object body) {
-        return chromaApiClient.put(path, body);
+    public Object proxyPut(String path, Object body) {
+        return extractBody(chromaApiClient.put(path, body));
     }
 
     @Override
-    public ResponseEntity<?> proxyPatch(String path, Object body) {
-        return chromaApiClient.patch(path, body);
+    public Object proxyPatch(String path, Object body) {
+        return extractBody(chromaApiClient.patch(path, body));
     }
 
     @Override
-    public ResponseEntity<?> proxyDelete(String path) {
-        return chromaApiClient.delete(path);
+    public Object proxyDelete(String path) {
+        return extractBody(chromaApiClient.delete(path));
+    }
+
+    private Object extractBody(ResponseEntity<?> responseEntity) {
+        if (responseEntity.getStatusCode().isError()) {
+            throw new RuntimeException("Proxy request failed with status " + responseEntity.getStatusCode());
+        }
+        return responseEntity.getBody();
     }
 }

--- a/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
@@ -18,74 +18,42 @@ public class ChromaAdminServiceImpl implements ChromaAdminService {
 
     @Override
     public Map<String, Object> getStats() {
-        try {
-            long count = vectorStore.count();
-            return Map.of(
-                    "count", count,
-                    "storeType", vectorStore.getClass().getSimpleName()
-            );
-        } catch (Exception e) {
-            log.error("获取Chroma统计信息失败", e);
-            throw new RuntimeException("获取Chroma统计信息失败: " + e.getMessage(), e);
-        }
+        long count = vectorStore.count();
+        return Map.of(
+                "count", count,
+                "storeType", vectorStore.getClass().getSimpleName()
+        );
     }
 
     @Override
     public Map<String, String> reset() {
-        try {
-            vectorStore.reset();
-            return Map.of("message", "Database reset successfully");
-        } catch (Exception e) {
-            log.error("重置Chroma数据库失败", e);
-            throw new RuntimeException("重置Chroma数据库失败: " + e.getMessage(), e);
-        }
+        vectorStore.reset();
+        return Map.of("message", "Database reset successfully");
     }
 
     @Override
     public Map<String, String> delete(Map<String, Object> filter) {
-        try {
-            if (filter == null || filter.isEmpty()) {
-                throw new IllegalArgumentException("Filter cannot be empty");
-            }
-            vectorStore.delete(filter);
-            return Map.of("message", "Documents deleted successfully");
-        } catch (IllegalArgumentException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("删除Chroma文档失败", e);
-            throw new RuntimeException("删除Chroma文档失败: " + e.getMessage(), e);
+        if (filter == null || filter.isEmpty()) {
+            throw new IllegalArgumentException("Filter cannot be empty");
         }
+        vectorStore.delete(filter);
+        return Map.of("message", "Documents deleted successfully");
     }
 
     @Override
     public Map<String, Object> healthcheck() {
-        try {
-            return chromaApiClient.getMap("/api/v2/healthcheck");
-        } catch (Exception e) {
-            log.error("获取Chroma健康状态失败", e);
-            throw new RuntimeException("获取Chroma健康状态失败: " + e.getMessage(), e);
-        }
+        return chromaApiClient.getMap("/api/v2/healthcheck");
     }
 
     @Override
     public Map<String, String> version() {
-        try {
-            String version = chromaApiClient.getString("/api/v2/version");
-            return Map.of("version", version != null ? version.replace("\"", "") : "unknown");
-        } catch (Exception e) {
-            log.error("获取Chroma版本失败", e);
-            throw new RuntimeException("获取Chroma版本失败: " + e.getMessage(), e);
-        }
+        String version = chromaApiClient.getString("/api/v2/version");
+        return Map.of("version", version != null ? version.replace("\"", "") : "unknown");
     }
 
     @Override
     public Map<String, Object> heartbeat() {
-        try {
-            return chromaApiClient.getMap("/api/v2/heartbeat");
-        } catch (Exception e) {
-            log.error("获取Chroma心跳失败", e);
-            throw new RuntimeException("获取Chroma心跳失败: " + e.getMessage(), e);
-        }
+        return chromaApiClient.getMap("/api/v2/heartbeat");
     }
 
     @Override

--- a/novel-splitter-web/src/api/chatApi.ts
+++ b/novel-splitter-web/src/api/chatApi.ts
@@ -4,6 +4,6 @@ import type { ChatRequest, Answer } from '@/types/api';
 export const chatApi = {
   sendMessage: async (request: ChatRequest): Promise<Answer> => {
     const response = await apiClient.post<Answer>('/chat', request);
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/chromaAdminApi.ts
+++ b/novel-splitter-web/src/api/chromaAdminApi.ts
@@ -49,52 +49,52 @@ export const chromaAdminApi = {
   // System
   getHealthcheck: async (): Promise<ChromaHealth> => {
     const response = await apiClient.get('/admin/chroma/healthcheck');
-    return response.data;
+    return response;
   },
   getVersion: async (): Promise<ChromaVersion> => {
     const response = await apiClient.get('/admin/chroma/version');
-    return response.data;
+    return response;
   },
   getHeartbeat: async (): Promise<ChromaHealth> => {
     const response = await apiClient.get('/admin/chroma/heartbeat');
-    return response.data;
+    return response;
   },
   getPreFlightChecks: async (): Promise<any> => {
     const response = await apiClient.get('/admin/chroma/pre-flight-checks');
-    return response.data;
+    return response;
   },
   getAuthIdentity: async (): Promise<any> => {
     const response = await apiClient.get('/admin/chroma/auth/identity');
-    return response.data;
+    return response;
   },
 
   // Tenants & Databases
   getTenants: async (): Promise<ChromaTenant[]> => {
     const response = await apiClient.get('/admin/chroma/tenants');
-    return response.data;
+    return response;
   },
   getDatabases: async (tenant: string): Promise<ChromaDatabase[]> => {
     const response = await apiClient.get(`/admin/chroma/tenants/${tenant}/databases`);
-    return response.data;
+    return response;
   },
 
   // Collections
   getCollections: async (): Promise<ChromaCollection[]> => {
     const response = await apiClient.get('/admin/chroma/collections');
-    return response.data;
+    return response;
   },
   getCollection: async (id: string): Promise<ChromaCollection> => {
     const response = await apiClient.get(`/admin/chroma/collections/${id}`);
-    return response.data;
+    return response;
   },
 
   // Records
   getRecords: async (collectionId: string, params: ChromaRecordQuery = {}): Promise<any> => {
     const response = await apiClient.post(`/admin/chroma/collections/${collectionId}/get`, params);
-    return response.data;
+    return response;
   },
   queryRecords: async (collectionId: string, params: ChromaQueryRequest): Promise<any> => {
     const response = await apiClient.post(`/admin/chroma/collections/${collectionId}/query`, params);
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/chromaApi.ts
+++ b/novel-splitter-web/src/api/chromaApi.ts
@@ -3,21 +3,21 @@ import { apiClient } from './client';
 export const chromaApi = {
   getHealthcheck: async () => {
     const response = await apiClient.get('/admin/chroma/healthcheck');
-    return response.data;
+    return response;
   },
 
   getVersion: async () => {
     const response = await apiClient.get('/admin/chroma/version');
-    return response.data;
+    return response;
   },
 
   getHeartbeat: async () => {
     const response = await apiClient.get('/admin/chroma/heartbeat');
-    return response.data;
+    return response;
   },
 
   getCollections: async () => {
     const response = await apiClient.get('/admin/chroma/collections');
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/client.ts
+++ b/novel-splitter-web/src/api/client.ts
@@ -1,5 +1,25 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { toast } from 'sonner';
+
+// 扩展 AxiosRequestConfig 支持自定义属性，并修改拦截器返回值类型
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    skipInterceptor?: boolean;
+    returnFullResponse?: boolean;
+  }
+  
+  // 重写 axios 的响应类型，让业务层调用 get/post 等方法时，自动推导返回 T 类型而不是 AxiosResponse<T>
+  export interface AxiosInstance {
+    request<T = any, R = T, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
+    get<T = any, R = T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+    delete<T = any, R = T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+    head<T = any, R = T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+    options<T = any, R = T, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R>;
+    post<T = any, R = T, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+    put<T = any, R = T, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+    patch<T = any, R = T, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R>;
+  }
+}
 
 export const apiClient = axios.create({
   baseURL: '/api',
@@ -35,14 +55,35 @@ apiClient.interceptors.response.use(
     if (enableApiLog) {
       console.log(`[API Response] <- ${response.config.method?.toUpperCase()} ${response.config.url}`, response);
     }
+
+    // 前端逃生舱：如果请求配置了 skipInterceptor 或 returnFullResponse，则跳过解包原样返回
+    if (response.config.skipInterceptor || response.config.returnFullResponse) {
+      return response;
+    }
+
+    const resData = response.data;
     
-    // 统一解包后端 ApiResponse 格式
-    // 采用替换 response.data 的方式，避免破坏所有上层 API 的 `return response.data` 签名
-    if (response.data && response.data.code === 200) {
-      response.data = response.data.data;
+    // 如果返回的不是 JSON 对象（如 Blob、ArrayBuffer 等下载文件场景），直接返回
+    if (!(resData instanceof Object) || resData instanceof Blob || resData instanceof ArrayBuffer) {
+        return resData;
     }
     
-    return response;
+    // 业务层面解包 (HTTP 200)
+    // 后端返回的永远是 { code, message, data }
+    if (resData.code !== undefined) {
+      if (resData.code === 200) {
+        // 业务成功，无感解包
+        return resData.data;
+      } else {
+        // 业务逻辑错误 (code !== 200)
+        const errorMessage = resData.message || '业务处理失败';
+        toast.error(errorMessage);
+        return Promise.reject(new Error(errorMessage));
+      }
+    }
+    
+    // 对于没有 code 的普通对象，原样返回
+    return resData;
   },
   (error) => {
     if (enableApiLog) {
@@ -51,7 +92,12 @@ apiClient.interceptors.response.use(
       console.error('API Error:', error);
     }
 
-    // 统一处理后端返回的 message 并弹窗
+    // 前端逃生舱：跳过错误拦截
+    if (error.config?.skipInterceptor) {
+        return Promise.reject(error);
+    }
+
+    // 统一处理后端返回的 HTTP 状态码错误 (如 401, 403, 404, 500)
     const data = error.response?.data;
     let errorMessage = '网络请求失败，请稍后重试';
 
@@ -64,10 +110,11 @@ apiClient.interceptors.response.use(
     // 弹窗提示
     toast.error(errorMessage);
 
-    // 针对 401 状态码特殊处理（例如跳转登录或提示）
+    // 针对 401 状态码特殊处理（例如跳转登录或清空状态）
     if (error.response?.status === 401) {
-      // TODO: 处理 401 逻辑，比如跳转到登录页或清空状态
       console.warn('Unauthorized access - 401');
+      // 可以触发全局事件或路由跳转，例如：
+      // window.dispatchEvent(new CustomEvent('auth-expired'));
     }
 
     return Promise.reject(error);

--- a/novel-splitter-web/src/api/downloadApi.ts
+++ b/novel-splitter-web/src/api/downloadApi.ts
@@ -4,6 +4,6 @@ import type { DownloadAndIngestRequest } from '@/types/api';
 export const downloadApi = {
   downloadAndIngest: async (request: DownloadAndIngestRequest): Promise<{ message: string; taskId?: string }> => {
     const response = await apiClient.post<{ message: string; taskId?: string }>('/v1/download/ingest', request);
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/knowledgeApi.ts
+++ b/novel-splitter-web/src/api/knowledgeApi.ts
@@ -4,12 +4,12 @@ import type { Scene } from '@/types/api';
 export const knowledgeApi = {
   getVersions: async (novelName: string): Promise<string[]> => {
     const response = await apiClient.get<string[]>(`/knowledge/${encodeURIComponent(novelName)}/versions`);
-    return response.data;
+    return response;
   },
 
   getScenes: async (novelName: string): Promise<Scene[]> => {
     const response = await apiClient.get<Scene[]>(`/knowledge/${encodeURIComponent(novelName)}/scenes`);
-    return response.data;
+    return response;
   },
 
   deleteVersion: async (novelName: string, version: string): Promise<void> => {

--- a/novel-splitter-web/src/api/novelApi.ts
+++ b/novel-splitter-web/src/api/novelApi.ts
@@ -4,7 +4,7 @@ import type { IngestRequest, NovelUploadResponse } from '@/types/api';
 export const novelApi = {
   getNovels: async (): Promise<string[]> => {
     const response = await apiClient.get<string[]>('/novels');
-    return response.data;
+    return response;
   },
 
   uploadNovel: async (file: File): Promise<NovelUploadResponse> => {
@@ -16,11 +16,11 @@ export const novelApi = {
         'Content-Type': 'multipart/form-data',
       },
     });
-    return response.data;
+    return response;
   },
 
   ingestNovel: async (request: IngestRequest): Promise<{ message: string }> => {
     const response = await apiClient.post<{ message: string }>('/novels/ingest', request);
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/ragApi.ts
+++ b/novel-splitter-web/src/api/ragApi.ts
@@ -4,6 +4,6 @@ import type { ChatRequest, RagDebugResponse } from '@/types/api';
 export const ragApi = {
   debug: async (request: ChatRequest): Promise<RagDebugResponse> => {
     const response = await apiClient.post<RagDebugResponse>('/v1/rag/debug', request);
-    return response.data;
+    return response;
   },
 };

--- a/novel-splitter-web/src/api/taskApi.ts
+++ b/novel-splitter-web/src/api/taskApi.ts
@@ -24,17 +24,17 @@ export interface TaskProgressEvent {
 export const taskApi = {
   getAllTasks: async (): Promise<SplitTask[]> => {
     const response = await apiClient.get<SplitTask[]>('/tasks');
-    return response.data;
+    return response;
   },
 
   getTask: async (taskId: string): Promise<SplitTask> => {
     const response = await apiClient.get<SplitTask>(`/tasks/${taskId}`);
-    return response.data;
+    return response;
   },
 
   getTaskEvents: async (taskId: string): Promise<TaskProgressEvent[]> => {
     const response = await apiClient.get<TaskProgressEvent[]>(`/tasks/${taskId}/events`);
-    return response.data;
+    return response;
   },
 
   deleteTask: async (taskId: string): Promise<void> => {

--- a/novel-splitter-web/src/api/vectorApi.ts
+++ b/novel-splitter-web/src/api/vectorApi.ts
@@ -4,12 +4,12 @@ import type { SystemStats, VectorSearchRequest, VectorRecord } from '@/types/api
 export const vectorApi = {
   getStats: async (): Promise<SystemStats> => {
     const response = await apiClient.get<SystemStats>('/admin/vector/stats');
-    return response.data;
+    return response;
   },
 
   search: async (request: VectorSearchRequest): Promise<VectorRecord[]> => {
     const response = await apiClient.post<VectorRecord[]>('/admin/vector/search', request);
-    return response.data;
+    return response;
   },
 
   delete: async (filter: Record<string, any>): Promise<void> => {


### PR DESCRIPTION
## 🎯 Changes

### 1. 后端API响应重构
- **ChromaManagementController**: 移除 `ResponseEntity` 包装，直接返回数据对象（`Map` 或 `Object`）。
- **ChromaAdminService**: 移除 `ResponseEntity` 包装，直接返回数据对象。
- **ChromaAdminServiceImpl**: 移除 `ResponseEntity` 包装和 `try-catch` 块，直接抛出异常，并新增 `extractBody` 私有方法统一处理代理请求响应。

### 2. 前端Axios拦截器增强
- **client.ts**: 
  - 扩展 `AxiosRequestConfig`，新增 `skipInterceptor` 和 `returnFullResponse` 配置项。
  - 重写 Axios 类型声明，实现业务数据类型的自动推导。
  - 增强响应拦截器，实现业务数据的自动解包，并支持通过配置跳过拦截器。
  - 完善错误拦截器逻辑，支持前端逃生舱并预留 401 状态码处理。
- **所有API接口文件 (chatApi.ts, chromaAdminApi.ts, chromaApi.ts, downloadApi.ts, knowledgeApi.ts, novelApi.ts, ragApi.ts, taskApi.ts, vectorApi.ts)**: 
  - 将方法返回值从 `response.data` 修改为直接返回 `response`，以适配新的拦截器解包逻辑。

## 💡 Technical Highlights

- **前后端统一响应范式**: 后端直接返回业务数据，前端通过拦截器统一处理，简化了客户端代码。
- **Axios类型推导优化**: 提升前端开发体验，减少手动类型断言。
- **灵活的拦截器配置**: 允许开发者根据需要跳过或自定义拦截器行为，增强了系统的可扩展性。
- **健壮的错误处理**: 统一的错误拦截器和 401 处理机制，提高了系统的稳定性和用户体验。