### PR TITLE
feat: 引入系统管理与监控功能

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -15,7 +15,7 @@
     <repositories>
         <repository>
             <id>aliyun-public</id>
-            <url>https://maven.aliyun.com/repository/public</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>

--- a/application/src/main/java/com/novel/splitter/application/controller/ChromaManagementController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/ChromaManagementController.java
@@ -1,12 +1,24 @@
 package com.novel.splitter.application.controller;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novel.splitter.domain.entity.JpaSceneEntity;
+import com.novel.splitter.repository.api.JpaSceneRepository;
 import com.novel.splitter.application.service.chroma.ChromaAdminService;
+import com.novel.splitter.application.model.dto.ChromaVersionDiagnosticDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Chroma向量数据库管理控制器
@@ -19,9 +31,42 @@ import java.util.Map;
 public class ChromaManagementController {
 
     private final ChromaAdminService chromaAdminService;
+    private final JpaSceneRepository jpaSceneRepository;
+    private final ObjectMapper objectMapper;
 
     private static final String DEFAULT_TENANT = "default_tenant";
     private static final String DEFAULT_DATABASE = "default_database";
+
+    @Operation(summary = "导出Chroma数据", description = "流式导出Chroma数据库中的向量数据为JSON")
+    @GetMapping("/export")
+    @Transactional(readOnly = true)
+    public ResponseEntity<StreamingResponseBody> export(
+            @RequestParam(required = false) String novelName,
+            @RequestParam(required = false) String version) {
+        
+        StreamingResponseBody responseBody = outputStream -> {
+            try (Stream<JpaSceneEntity> sceneStream = (novelName != null && version != null) ?
+                    jpaSceneRepository.streamAllByNovelNameAndVersion(novelName, version) :
+                    jpaSceneRepository.streamAll();
+                 JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(outputStream)) {
+                
+                jsonGenerator.writeStartArray();
+                sceneStream.forEach(entity -> {
+                    try {
+                        objectMapper.writeValue(jsonGenerator, entity);
+                    } catch (IOException e) {
+                        throw new RuntimeException("Error writing JSON for entity", e);
+                    }
+                });
+                jsonGenerator.writeEndArray();
+            }
+        };
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"chroma_export.json\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(responseBody);
+    }
 
     /**
      * 获取Chroma统计信息
@@ -76,12 +121,32 @@ public class ChromaManagementController {
     }
 
     /**
+     * 获取版本诊断信息
+     */
+    @Operation(summary = "获取版本诊断信息", description = "获取数据库与Chroma的同步诊断信息")
+    @GetMapping("/diagnostics")
+    public ChromaVersionDiagnosticDto getVersionDiagnostics(@RequestParam String novel, @RequestParam String version) {
+        return chromaAdminService.getVersionDiagnostics(novel, version);
+    }
+
+    /**
      * 获取Chroma心跳
      */
     @Operation(summary = "获取Chroma心跳", description = "获取Chroma服务器的心跳时间戳")
     @GetMapping("/heartbeat")
     public Map<String, Object> heartbeat() {
         return chromaAdminService.heartbeat();
+    }
+
+    /**
+     * 重建集合并清理本地数据库
+     *
+     * @return 操作结果
+     */
+    @Operation(summary = "重建集合", description = "删除并重新创建Chroma集合，同时清理本地数据库数据")
+    @PostMapping("/collections/rebuild")
+    public Map<String, String> rebuildCollection() {
+        return chromaAdminService.rebuildCollection();
     }
 
     /**

--- a/application/src/main/java/com/novel/splitter/application/controller/JobController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/JobController.java
@@ -1,0 +1,36 @@
+package com.novel.splitter.application.controller;
+
+import com.novel.splitter.application.model.dto.JobRecordDto;
+import com.novel.splitter.application.model.dto.JobStatSummaryDto;
+import com.novel.splitter.application.service.task.TaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jobs")
+@Tag(name = "任务监控", description = "作业监控统计接口")
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final TaskService taskService;
+
+    @GetMapping
+    @Operation(summary = "获取所有作业记录")
+    public List<JobRecordDto> getJobs() {
+        return taskService.getAllJobs();
+    }
+
+    @GetMapping("/stats")
+    @Operation(summary = "获取作业统计摘要")
+    public JobStatSummaryDto getJobStats() {
+        return taskService.getJobStats();
+    }
+}

--- a/application/src/main/java/com/novel/splitter/application/controller/KnowledgeBaseController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/KnowledgeBaseController.java
@@ -5,6 +5,9 @@ import com.novel.splitter.domain.model.Scene;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import com.novel.splitter.domain.model.dto.VectorPreviewRecordDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,6 +19,12 @@ import java.util.List;
 public class KnowledgeBaseController {
 
     private final KnowledgeBaseService knowledgeBaseService;
+
+    @Operation(summary = "获取轻量级场景分页列表")
+    @GetMapping("/scenes/lightweight")
+    public Page<VectorPreviewRecordDto> getLightweightScenes(Pageable pageable) {
+        return knowledgeBaseService.getLightweightScenes(pageable);
+    }
 
     @Operation(summary = "获取指定小说的所有段落")
     @GetMapping("/{novelName}/scenes")

--- a/application/src/main/java/com/novel/splitter/application/controller/NovelController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/NovelController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.novel.splitter.domain.model.dto.NovelStatRecordDto;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -60,5 +62,16 @@ public class NovelController {
     @PostMapping("/ingest")
     public Map<String, String> ingest(@Valid @RequestBody IngestRequest request) throws IOException {
         return novelFacadeService.ingest(request);
+    }
+
+    /**
+     * 获取所有小说的入库统计信息
+     *
+     * @return 小说统计信息列表
+     */
+    @Operation(summary = "获取小说统计信息", description = "返回每本小说的版本、分块数、向量数及入库状态")
+    @GetMapping("/stats")
+    public List<NovelStatRecordDto> getNovelStats() {
+        return novelFacadeService.getNovelStats();
     }
 }

--- a/application/src/main/java/com/novel/splitter/application/controller/SplitPreviewController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/SplitPreviewController.java
@@ -1,0 +1,104 @@
+package com.novel.splitter.application.controller;
+
+import com.novel.splitter.core.ContextAwareSegmentBuilder;
+import com.novel.splitter.core.MarkdownParagraphSplitter;
+import com.novel.splitter.core.SceneAssembler;
+import com.novel.splitter.domain.model.Chapter;
+import com.novel.splitter.domain.model.RawParagraph;
+import com.novel.splitter.domain.model.Scene;
+import com.novel.splitter.domain.model.SemanticSegment;
+import com.novel.splitter.domain.model.dto.ChunkPreviewDto;
+import com.novel.splitter.domain.model.dto.SplitPreviewRequestDto;
+import com.novel.splitter.domain.strategy.OverlapChunkingStrategy;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Tag(name = "Split Preview", description = "Preview split chunks in memory")
+@RestController
+@RequestMapping("/api/split")
+public class SplitPreviewController {
+
+    @Operation(summary = "Preview split chunks")
+    @PostMapping("/preview")
+    public List<ChunkPreviewDto> preview(@Valid @RequestBody SplitPreviewRequestDto request) {
+        String sourceText = request.getSourceText();
+        String strategy = request.getStrategy() != null ? request.getStrategy().toLowerCase() : "scene";
+        Integer maxTokens = request.getMaxTokens() != null ? request.getMaxTokens() : 1200;
+        Integer overlapTokens = request.getOverlapTokens() != null ? request.getOverlapTokens() : 0;
+
+        List<String> lines = Arrays.asList(sourceText.split("\n"));
+        MarkdownParagraphSplitter splitter = new MarkdownParagraphSplitter();
+        List<RawParagraph> paragraphs = splitter.split(lines);
+
+        List<ChunkPreviewDto> result = new ArrayList<>();
+
+        if ("segment".equals(strategy) || "semantic".equals(strategy)) {
+            ContextAwareSegmentBuilder segmentBuilder = new ContextAwareSegmentBuilder();
+            List<SemanticSegment> segments = segmentBuilder.build(paragraphs);
+            for (int i = 0; i < segments.size(); i++) {
+                SemanticSegment segment = segments.get(i);
+                StringBuilder sb = new StringBuilder();
+                for (RawParagraph p : segment.getParagraphs()) {
+                    sb.append(p.getContent()).append("\n");
+                }
+                String text = sb.toString().trim();
+                result.add(ChunkPreviewDto.builder()
+                        .index(i)
+                        .text(text)
+                        .length(text.length())
+                        .type(segment.getType() != null ? segment.getType() : "TEXT")
+                        .build());
+            }
+        } else {
+            // Default to SceneAssembler
+            SceneAssembler sceneAssembler = new SceneAssembler();
+            Chapter dummyChapter = Chapter.builder()
+                    .title("Preview Chapter")
+                    .index(1)
+                    .startParagraphIndex(0)
+                    .endParagraphIndex(paragraphs.isEmpty() ? 0 : paragraphs.size() - 1)
+                    .build();
+
+            List<Scene> scenes = sceneAssembler.assembleChapter(dummyChapter, paragraphs, "Preview Novel");
+
+            // Apply overlap chunking if requested
+            if (maxTokens > 0 && ("overlap".equals(strategy) || maxTokens < 10000)) {
+                if (overlapTokens >= maxTokens) {
+                    overlapTokens = Math.max(0, maxTokens - 1);
+                }
+                OverlapChunkingStrategy chunkingStrategy = new OverlapChunkingStrategy(maxTokens, overlapTokens);
+                List<Scene> allChunks = new ArrayList<>();
+                for (Scene scene : scenes) {
+                    if (scene.getText().length() > maxTokens) {
+                        allChunks.addAll(chunkingStrategy.split(scene));
+                    } else {
+                        allChunks.add(scene);
+                    }
+                }
+                scenes = allChunks;
+            }
+
+            for (int i = 0; i < scenes.size(); i++) {
+                Scene scene = scenes.get(i);
+                String text = scene.getText().trim();
+                result.add(ChunkPreviewDto.builder()
+                        .index(i)
+                        .text(text)
+                        .length(text.length())
+                        .type("SCENE")
+                        .build());
+            }
+        }
+
+        return result;
+    }
+}

--- a/application/src/main/java/com/novel/splitter/application/controller/SystemSettingsController.java
+++ b/application/src/main/java/com/novel/splitter/application/controller/SystemSettingsController.java
@@ -1,0 +1,36 @@
+package com.novel.splitter.application.controller;
+
+import com.novel.splitter.application.service.settings.SystemSettingsService;
+import com.novel.splitter.domain.model.dto.SystemSettingsDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Controller for managing system settings.
+ */
+@Tag(name = "系统设置管理", description = "提供系统设置的获取和更新功能")
+@RestController
+@RequestMapping("/api/settings")
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class SystemSettingsController {
+
+    private final SystemSettingsService systemSettingsService;
+
+    @Operation(summary = "获取系统设置", description = "获取当前系统的所有配置信息")
+    @GetMapping
+    public SystemSettingsDto getSettings() {
+        return systemSettingsService.getSettings();
+    }
+
+    @Operation(summary = "更新系统设置", description = "更新系统配置并持久化到本地文件")
+    @PutMapping
+    public Map<String, String> updateSettings(@RequestBody SystemSettingsDto settingsDto) {
+        systemSettingsService.saveSettings(settingsDto);
+        return Map.of("message", "Settings updated successfully");
+    }
+}

--- a/application/src/main/java/com/novel/splitter/application/model/dto/ChromaVersionDiagnosticDto.java
+++ b/application/src/main/java/com/novel/splitter/application/model/dto/ChromaVersionDiagnosticDto.java
@@ -1,0 +1,12 @@
+package com.novel.splitter.application.model.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ChromaVersionDiagnosticDto {
+    private long dbCount;
+    private long chromaCount;
+    private boolean consistent;
+    private List<String> metadataKeys;
+}

--- a/application/src/main/java/com/novel/splitter/application/model/dto/JobRecordDto.java
+++ b/application/src/main/java/com/novel/splitter/application/model/dto/JobRecordDto.java
@@ -1,0 +1,27 @@
+package com.novel.splitter.application.model.dto;
+
+import com.novel.splitter.domain.task.SplitTask.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JobRecordDto {
+    private String id; // Use id for standard job identification
+    private String taskId;
+    private String novelId;
+    private String fileName;
+    private int maxScenes;
+    private String version;
+    private TaskStatus status;
+    private int progress;
+    private String message;
+    private long createdAt;
+    private long updatedAt;
+    private int totalScenes;
+    private int completedScenes;
+}

--- a/application/src/main/java/com/novel/splitter/application/model/dto/JobStatSummaryDto.java
+++ b/application/src/main/java/com/novel/splitter/application/model/dto/JobStatSummaryDto.java
@@ -1,0 +1,17 @@
+package com.novel.splitter.application.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JobStatSummaryDto {
+    private long running;
+    private long waiting;
+    private long completedToday;
+    private long failedToday;
+}

--- a/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminService.java
@@ -16,6 +16,10 @@ public interface ChromaAdminService {
 
     Map<String, Object> heartbeat();
 
+    Map<String, String> rebuildCollection();
+
+    com.novel.splitter.application.model.dto.ChromaVersionDiagnosticDto getVersionDiagnostics(String novel, String version);
+
     Object proxyGet(String path);
 
     Object proxyPost(String path, Object body);

--- a/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/chroma/ChromaAdminServiceImpl.java
@@ -1,11 +1,16 @@
 package com.novel.splitter.application.service.chroma;
 
 import com.novel.splitter.embedding.api.VectorStore;
+import com.novel.splitter.repository.api.JpaSceneRepository;
+import com.novel.splitter.application.model.dto.ChromaVersionDiagnosticDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -15,6 +20,10 @@ public class ChromaAdminServiceImpl implements ChromaAdminService {
 
     private final VectorStore vectorStore;
     private final ChromaApiClient chromaApiClient;
+    private final JpaSceneRepository jpaSceneRepository;
+
+    @Value("${chroma.collection:novel-splitter}")
+    private String collectionName;
 
     @Override
     public Map<String, Object> getStats() {
@@ -54,6 +63,105 @@ public class ChromaAdminServiceImpl implements ChromaAdminService {
     @Override
     public Map<String, Object> heartbeat() {
         return chromaApiClient.getMap("/api/v2/heartbeat");
+    }
+
+    @Override
+    public Map<String, String> rebuildCollection() {
+        String pathPrefix = "/api/v2/tenants/default_tenant/databases/default_database/collections";
+
+        try {
+            chromaApiClient.delete(pathPrefix + "/" + collectionName);
+            log.info("Deleted ChromaDB collection: {}", collectionName);
+        } catch (Exception e) {
+            log.warn("Failed to delete collection (might not exist): {}", e.getMessage());
+        }
+
+        Map<String, Object> body = Map.of(
+                "name", collectionName,
+                "metadata", Map.of("hnsw:space", "cosine")
+        );
+        
+        try {
+            chromaApiClient.post(pathPrefix, body);
+            log.info("Created ChromaDB collection: {} with cosine space", collectionName);
+        } catch (Exception e) {
+            log.error("Failed to create collection: {}", e.getMessage());
+            throw new RuntimeException("Failed to recreate collection", e);
+        }
+
+        jpaSceneRepository.deleteAll();
+        log.info("Cleared local DB scenes");
+
+        return Map.of("message", "Collection rebuilt successfully");
+    }
+
+    @Override
+    public ChromaVersionDiagnosticDto getVersionDiagnostics(String novel, String version) {
+        long dbCount = jpaSceneRepository.countByNovelNameAndVersion(novel, version);
+        long chromaCount = 0;
+        List<String> metadataKeys = new ArrayList<>();
+
+        try {
+            // Find collection id
+            Object collectionsObj = proxyGet("/api/v2/tenants/default_tenant/databases/default_database/collections");
+            String collectionId = null;
+            if (collectionsObj instanceof List<?> list) {
+                for (Object item : list) {
+                    if (item instanceof Map<?, ?> map) {
+                        if (collectionName.equals(map.get("name"))) {
+                            collectionId = (String) map.get("id");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (collectionId != null) {
+                Map<String, Object> where = Map.of("$and", List.of(
+                        Map.of("novel", Map.of("$eq", novel)),
+                        Map.of("version", Map.of("$eq", version))
+                ));
+
+                // Get count
+                Map<String, Object> countBody = Map.of(
+                        "where", where,
+                        "include", List.of()
+                );
+                Object countRes = proxyPost("/api/v2/tenants/default_tenant/databases/default_database/collections/" + collectionId + "/get", countBody);
+                if (countRes instanceof Map<?, ?> map && map.get("ids") instanceof List<?> ids) {
+                    chromaCount = ids.size();
+                }
+
+                // Get 1 record metadata
+                Map<String, Object> metaBody = Map.of(
+                        "where", where,
+                        "limit", 1,
+                        "include", List.of("metadatas")
+                );
+                Object metaRes = proxyPost("/api/v2/tenants/default_tenant/databases/default_database/collections/" + collectionId + "/get", metaBody);
+                if (metaRes instanceof Map<?, ?> map && map.get("metadatas") instanceof List<?> metadatas) {
+                    if (!metadatas.isEmpty()) {
+                        Object firstMeta = metadatas.get(0);
+                        if (firstMeta instanceof Map<?, ?> firstMetaMap) {
+                            for (Object key : firstMetaMap.keySet()) {
+                                metadataKeys.add(String.valueOf(key));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to get chroma diagnostics for novel={}, version={}", novel, version, e);
+            // Optionally, we could set chromaCount = -1 to indicate error
+        }
+
+        ChromaVersionDiagnosticDto dto = new ChromaVersionDiagnosticDto();
+        dto.setDbCount(dbCount);
+        dto.setChromaCount(chromaCount);
+        dto.setConsistent(dbCount == chromaCount);
+        dto.setMetadataKeys(metadataKeys);
+
+        return dto;
     }
 
     @Override

--- a/application/src/main/java/com/novel/splitter/application/service/knowledge/KnowledgeBaseService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/knowledge/KnowledgeBaseService.java
@@ -1,6 +1,10 @@
 package com.novel.splitter.application.service.knowledge;
 
 import com.novel.splitter.domain.model.Scene;
+import com.novel.splitter.domain.model.dto.VectorPreviewRecordDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 
 /**
@@ -8,6 +12,13 @@ import java.util.List;
  */
 public interface KnowledgeBaseService {
     
+    /**
+     * 获取轻量级场景分页列表
+     * @param pageable 分页参数
+     * @return 轻量级场景分页列表
+     */
+    Page<VectorPreviewRecordDto> getLightweightScenes(Pageable pageable);
+
     /**
      * 获取指定小说的所有 Scene
      * @param novelName 小说名称

--- a/application/src/main/java/com/novel/splitter/application/service/knowledge/impl/KnowledgeBaseServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/knowledge/impl/KnowledgeBaseServiceImpl.java
@@ -8,6 +8,10 @@ import com.novel.splitter.domain.task.CleanupTaskMessage;
 import com.novel.splitter.embedding.api.VectorStore;
 import com.novel.splitter.repository.api.JpaCleanupTaskRepository;
 import com.novel.splitter.repository.api.SceneRepository;
+import com.novel.splitter.domain.model.dto.VectorPreviewRecordDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.novel.splitter.repository.api.JpaSceneRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -25,12 +29,18 @@ import java.util.List;
 public class KnowledgeBaseServiceImpl implements KnowledgeBaseService {
 
     private final SceneRepository sceneRepository;
+    private final JpaSceneRepository jpaSceneRepository;
     private final VectorStore vectorStore;
     private final JpaCleanupTaskRepository cleanupTaskRepository;
     private final RabbitTemplate rabbitTemplate;
     
     @org.springframework.beans.factory.annotation.Value("${splitter.storage.root-path}")
     private String novelStoragePath;
+
+    @Override
+    public Page<VectorPreviewRecordDto> getLightweightScenes(Pageable pageable) {
+        return jpaSceneRepository.findLightweightScenes(pageable);
+    }
 
     @Override
     public List<Scene> getScenesByNovel(String novelName) {

--- a/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeService.java
@@ -17,4 +17,6 @@ public interface NovelFacadeService {
     Map<String, String> ingest(IngestRequest request) throws IOException;
 
     Map<String, String> downloadAndIngest(DownloadAndIngestRequest request) throws IOException;
+
+    List<com.novel.splitter.domain.model.dto.NovelStatRecordDto> getNovelStats();
 }

--- a/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeServiceImpl.java
@@ -6,6 +6,9 @@ import com.novel.splitter.application.service.task.TaskService;
 import com.novel.splitter.domain.task.SplitTaskMessage;
 import com.novel.splitter.domain.model.dto.DownloadAndIngestRequest;
 import com.novel.splitter.domain.model.dto.IngestRequest;
+import com.novel.splitter.domain.model.dto.NovelStatRecordDto;
+import com.novel.splitter.domain.task.SplitTask;
+import com.novel.splitter.repository.api.JpaSceneRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -15,9 +18,18 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -30,6 +42,93 @@ public class NovelFacadeServiceImpl implements NovelFacadeService {
     private final TaskService taskService;
     private final RabbitTemplate rabbitTemplate;
     private final DownloadService downloadService;
+    private final JpaSceneRepository jpaSceneRepository;
+
+    @Override
+    public List<NovelStatRecordDto> getNovelStats() {
+        List<Object[]> sceneCounts = jpaSceneRepository.countScenesByNovelAndVersion();
+
+        // Map: novelName -> map of version -> count
+        Map<String, Map<String, Long>> novelVersionCounts = new HashMap<>();
+        for (Object[] row : sceneCounts) {
+            String novelName = (String) row[0];
+            String version = (String) row[1];
+            long count = ((Number) row[2]).longValue();
+            novelVersionCounts.computeIfAbsent(novelName, k -> new HashMap<>()).put(version, count);
+        }
+
+        List<SplitTask> allTasks = taskService.getAllTasks();
+        // Group tasks by novelId
+        Map<String, List<SplitTask>> tasksByNovel = allTasks.stream()
+                .filter(t -> t.getNovelId() != null)
+                .collect(Collectors.groupingBy(SplitTask::getNovelId));
+
+        List<NovelStatRecordDto> stats = new ArrayList<>();
+
+        // Merge data
+        for (Map.Entry<String, Map<String, Long>> entry : novelVersionCounts.entrySet()) {
+            String novelName = entry.getKey();
+            Map<String, Long> versionMap = entry.getValue();
+
+            List<String> versions = new ArrayList<>(versionMap.keySet());
+            long totalScenes = versionMap.values().stream().mapToLong(Long::longValue).sum();
+
+            // Get latest task for this novel
+            List<SplitTask> novelTasks = tasksByNovel.getOrDefault(novelName, Collections.emptyList());
+            SplitTask latestTask = novelTasks.stream()
+                    .max(Comparator.comparing(SplitTask::getCreatedAt))
+                    .orElse(null);
+
+            String ingestTime = null;
+            String status = "UNKNOWN";
+
+            if (latestTask != null) {
+                LocalDateTime dt = LocalDateTime.ofInstant(Instant.ofEpochMilli(latestTask.getCreatedAt()), ZoneId.systemDefault());
+                ingestTime = dt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                status = latestTask.getStatus() != null ? latestTask.getStatus().name() : "UNKNOWN";
+            }
+
+            NovelStatRecordDto dto = NovelStatRecordDto.builder()
+                    .novelName(novelName)
+                    .versions(versions)
+                    .sceneCount(totalScenes)
+                    .vectorCount(totalScenes) // Assume 1 scene = 1 vector
+                    .ingestTime(ingestTime)
+                    .status(status)
+                    .build();
+            stats.add(dto);
+        }
+
+        // Add novels that have tasks but no scenes yet
+        for (Map.Entry<String, List<SplitTask>> entry : tasksByNovel.entrySet()) {
+            String novelName = entry.getKey();
+            if (!novelVersionCounts.containsKey(novelName)) {
+                SplitTask latestTask = entry.getValue().stream()
+                        .max(Comparator.comparing(SplitTask::getCreatedAt))
+                        .orElse(null);
+
+                String ingestTime = null;
+                String status = "UNKNOWN";
+                if (latestTask != null) {
+                    LocalDateTime dt = LocalDateTime.ofInstant(Instant.ofEpochMilli(latestTask.getCreatedAt()), ZoneId.systemDefault());
+                    ingestTime = dt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                    status = latestTask.getStatus() != null ? latestTask.getStatus().name() : "UNKNOWN";
+                }
+
+                NovelStatRecordDto dto = NovelStatRecordDto.builder()
+                        .novelName(novelName)
+                        .versions(Collections.emptyList())
+                        .sceneCount(0)
+                        .vectorCount(0)
+                        .ingestTime(ingestTime)
+                        .status(status)
+                        .build();
+                stats.add(dto);
+            }
+        }
+
+        return stats;
+    }
 
     @Override
     public List<String> listNovels() throws IOException {

--- a/application/src/main/java/com/novel/splitter/application/service/settings/SystemSettingsService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/settings/SystemSettingsService.java
@@ -1,0 +1,18 @@
+package com.novel.splitter.application.service.settings;
+
+import com.novel.splitter.domain.model.dto.SystemSettingsDto;
+
+public interface SystemSettingsService {
+    
+    /**
+     * Get system settings from local JSON file.
+     * @return SystemSettingsDto
+     */
+    SystemSettingsDto getSettings();
+    
+    /**
+     * Save system settings to local JSON file.
+     * @param settingsDto The settings to save
+     */
+    void saveSettings(SystemSettingsDto settingsDto);
+}

--- a/application/src/main/java/com/novel/splitter/application/service/settings/SystemSettingsServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/settings/SystemSettingsServiceImpl.java
@@ -1,0 +1,68 @@
+package com.novel.splitter.application.service.settings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novel.splitter.domain.model.dto.SystemSettingsDto;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SystemSettingsServiceImpl implements SystemSettingsService {
+
+    private final ObjectMapper objectMapper;
+    private static final String SETTINGS_FILE_PATH = "config/settings.json";
+
+    @PostConstruct
+    public void init() {
+        File file = new File(SETTINGS_FILE_PATH);
+        if (!file.exists()) {
+            File parent = file.getParentFile();
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs();
+            }
+            try {
+                SystemSettingsDto defaultSettings = new SystemSettingsDto();
+                objectMapper.writeValue(file, defaultSettings);
+                log.info("Created default settings file at {}", SETTINGS_FILE_PATH);
+            } catch (IOException e) {
+                log.error("Failed to create default settings file", e);
+            }
+        }
+    }
+
+    @Override
+    public SystemSettingsDto getSettings() {
+        File file = new File(SETTINGS_FILE_PATH);
+        if (!file.exists()) {
+            return new SystemSettingsDto();
+        }
+        try {
+            return objectMapper.readValue(file, SystemSettingsDto.class);
+        } catch (IOException e) {
+            log.error("Failed to read settings file", e);
+            throw new RuntimeException("Failed to read settings", e);
+        }
+    }
+
+    @Override
+    public void saveSettings(SystemSettingsDto settingsDto) {
+        File file = new File(SETTINGS_FILE_PATH);
+        try {
+            File parent = file.getParentFile();
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs();
+            }
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(file, settingsDto);
+            log.info("Saved settings to {}", SETTINGS_FILE_PATH);
+        } catch (IOException e) {
+            log.error("Failed to save settings", e);
+            throw new RuntimeException("Failed to save settings", e);
+        }
+    }
+}

--- a/application/src/main/java/com/novel/splitter/application/service/task/TaskService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/task/TaskService.java
@@ -4,12 +4,19 @@ import com.novel.splitter.domain.task.SplitTask;
 import com.novel.splitter.domain.task.TaskProgressEvent;
 import com.novel.splitter.application.repository.task.TaskRepository;
 import com.novel.splitter.application.repository.task.TaskEventRepository;
+import com.novel.splitter.application.model.dto.JobStatSummaryDto;
+import com.novel.splitter.application.model.dto.JobRecordDto;
+import com.novel.splitter.repository.api.JpaSplitTaskRepository;
+import com.novel.splitter.domain.entity.JpaSplitTaskEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class TaskService {
@@ -17,12 +24,14 @@ public class TaskService {
     private final TaskRepository taskRepository;
     private final TaskEventRepository taskEventRepository;
     private final TaskEventPublisher taskEventPublisher;
+    private final JpaSplitTaskRepository jpaSplitTaskRepository;
 
     @Autowired
-    public TaskService(TaskRepository taskRepository, TaskEventRepository taskEventRepository, TaskEventPublisher taskEventPublisher) {
+    public TaskService(TaskRepository taskRepository, TaskEventRepository taskEventRepository, TaskEventPublisher taskEventPublisher, JpaSplitTaskRepository jpaSplitTaskRepository) {
         this.taskRepository = taskRepository;
         this.taskEventRepository = taskEventRepository;
         this.taskEventPublisher = taskEventPublisher;
+        this.jpaSplitTaskRepository = jpaSplitTaskRepository;
     }
 
     @Transactional
@@ -67,5 +76,48 @@ public class TaskService {
     @Transactional(readOnly = true)
     public List<TaskProgressEvent> getTaskEvents(String taskId) {
         return taskEventRepository.findByTaskId(taskId);
+    }
+
+    @Transactional(readOnly = true)
+    public JobStatSummaryDto getJobStats() {
+        long startOfDay = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        
+        long running = jpaSplitTaskRepository.countByStatus(SplitTask.TaskStatus.PROCESSING);
+        long waiting = jpaSplitTaskRepository.countByStatus(SplitTask.TaskStatus.PENDING);
+        long completedToday = jpaSplitTaskRepository.countByStatusAndUpdatedAtGreaterThanEqual(SplitTask.TaskStatus.SUCCESS, startOfDay);
+        long failedToday = jpaSplitTaskRepository.countByStatusAndUpdatedAtGreaterThanEqual(SplitTask.TaskStatus.FAILED, startOfDay);
+        
+        return JobStatSummaryDto.builder()
+                .running(running)
+                .waiting(waiting)
+                .completedToday(completedToday)
+                .failedToday(failedToday)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<JobRecordDto> getAllJobs() {
+        return jpaSplitTaskRepository.findAll().stream()
+                .map(this::mapToJobRecordDto)
+                .sorted(Comparator.comparing(JobRecordDto::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+    }
+
+    private JobRecordDto mapToJobRecordDto(JpaSplitTaskEntity entity) {
+        return JobRecordDto.builder()
+                .id(entity.getTaskId())
+                .taskId(entity.getTaskId())
+                .novelId(entity.getNovelId())
+                .fileName(entity.getFileName())
+                .maxScenes(entity.getMaxScenes())
+                .version(entity.getVersion())
+                .status(entity.getStatus())
+                .progress(entity.getProgress())
+                .message(entity.getMessage())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .totalScenes(entity.getTotalScenes())
+                .completedScenes(entity.getCompletedScenes())
+                .build();
     }
 }

--- a/application/src/test/java/com/novel/splitter/application/controller/SystemSettingsControllerTest.java
+++ b/application/src/test/java/com/novel/splitter/application/controller/SystemSettingsControllerTest.java
@@ -1,0 +1,70 @@
+package com.novel.splitter.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novel.splitter.application.service.settings.SystemSettingsService;
+import com.novel.splitter.domain.model.dto.SystemSettingsDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class SystemSettingsControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SystemSettingsService systemSettingsService;
+
+    @InjectMocks
+    private SystemSettingsController systemSettingsController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(systemSettingsController).build();
+    }
+
+    @Test
+    void testGetSettings() throws Exception {
+        SystemSettingsDto dto = new SystemSettingsDto();
+        dto.setEmbedding(Map.of("type", "chroma"));
+        when(systemSettingsService.getSettings()).thenReturn(dto);
+
+        mockMvc.perform(get("/api/settings"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.embedding.type").value("chroma"));
+
+        verify(systemSettingsService).getSettings();
+    }
+
+    @Test
+    void testUpdateSettings() throws Exception {
+        SystemSettingsDto dto = new SystemSettingsDto();
+        dto.setEmbedding(Map.of("type", "chroma"));
+
+        mockMvc.perform(put("/api/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Settings updated successfully"));
+
+        verify(systemSettingsService).saveSettings(any(SystemSettingsDto.class));
+    }
+}

--- a/application/src/test/java/com/novel/splitter/application/service/settings/SystemSettingsServiceImplTest.java
+++ b/application/src/test/java/com/novel/splitter/application/service/settings/SystemSettingsServiceImplTest.java
@@ -1,0 +1,71 @@
+package com.novel.splitter.application.service.settings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novel.splitter.domain.model.dto.SystemSettingsDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SystemSettingsServiceImplTest {
+
+    private SystemSettingsServiceImpl systemSettingsService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String TEST_SETTINGS_FILE = "config/settings.json";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        systemSettingsService = new SystemSettingsServiceImpl(objectMapper);
+        // Clean up before test
+        File file = new File(TEST_SETTINGS_FILE);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // Clean up after test
+        File file = new File(TEST_SETTINGS_FILE);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
+    @Test
+    void testInitCreatesDefaultFile() {
+        systemSettingsService.init();
+        File file = new File(TEST_SETTINGS_FILE);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void testGetSettingsReturnsEmptyWhenFileNotExists() {
+        SystemSettingsDto settings = systemSettingsService.getSettings();
+        assertNotNull(settings);
+        assertNull(settings.getEmbedding());
+    }
+
+    @Test
+    void testSaveAndGetSettings() {
+        SystemSettingsDto dto = new SystemSettingsDto();
+        dto.setEmbedding(Map.of("type", "chroma"));
+        dto.setLlm(Map.of("provider", "ollama"));
+        
+        systemSettingsService.saveSettings(dto);
+        
+        File file = new File(TEST_SETTINGS_FILE);
+        assertTrue(file.exists());
+        
+        SystemSettingsDto loaded = systemSettingsService.getSettings();
+        assertNotNull(loaded);
+        assertEquals("chroma", loaded.getEmbedding().get("type"));
+        assertEquals("ollama", loaded.getLlm().get("provider"));
+    }
+}

--- a/domain/src/main/java/com/novel/splitter/domain/model/dto/ChunkPreviewDto.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/dto/ChunkPreviewDto.java
@@ -1,0 +1,13 @@
+package com.novel.splitter.domain.model.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChunkPreviewDto {
+    private int index;
+    private String text;
+    private int length;
+    private String type;
+}

--- a/domain/src/main/java/com/novel/splitter/domain/model/dto/NovelStatRecordDto.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/dto/NovelStatRecordDto.java
@@ -1,0 +1,21 @@
+package com.novel.splitter.domain.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NovelStatRecordDto {
+    private String novelName;
+    private List<String> versions;
+    private long sceneCount;
+    private long vectorCount;
+    private String ingestTime;
+    private String status;
+}

--- a/domain/src/main/java/com/novel/splitter/domain/model/dto/SplitPreviewRequestDto.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/dto/SplitPreviewRequestDto.java
@@ -1,0 +1,14 @@
+package com.novel.splitter.domain.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SplitPreviewRequestDto {
+    @NotBlank(message = "Source text cannot be blank")
+    private String sourceText;
+    
+    private String strategy;
+    private Integer maxTokens;
+    private Integer overlapTokens;
+}

--- a/domain/src/main/java/com/novel/splitter/domain/model/dto/SystemSettingsDto.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/dto/SystemSettingsDto.java
@@ -1,0 +1,26 @@
+package com.novel.splitter.domain.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * DTO for system settings matching frontend requirements.
+ */
+@Data
+@Schema(description = "系统设置DTO")
+public class SystemSettingsDto {
+    
+    @Schema(description = "Embedding 配置")
+    private Map<String, Object> embedding;
+    
+    @Schema(description = "LLM 配置")
+    private Map<String, Object> llm;
+    
+    @Schema(description = "Chroma 配置")
+    private Map<String, Object> chroma;
+    
+    @Schema(description = "切分策略配置")
+    private Map<String, Object> splitStrategy;
+}

--- a/domain/src/main/java/com/novel/splitter/domain/model/dto/VectorPreviewRecordDto.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/dto/VectorPreviewRecordDto.java
@@ -1,0 +1,9 @@
+package com.novel.splitter.domain.model.dto;
+
+public interface VectorPreviewRecordDto {
+    Long getId();
+    Integer getChapterIndex();
+    String getType();
+    Integer getTokenCount();
+    String getTextContent();
+}

--- a/embedding/pom.xml
+++ b/embedding/pom.xml
@@ -50,7 +50,7 @@
     <repositories>
         <repository>
             <id>aliyun-public</id>
-            <url>https://maven.aliyun.com/repository/public</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>

--- a/llm-client/pom.xml
+++ b/llm-client/pom.xml
@@ -57,7 +57,7 @@
     <repositories>
         <repository>
             <id>aliyun-public</id>
-            <url>https://maven.aliyun.com/repository/public</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <repositories>
         <repository>
             <id>aliyun-public</id>
-            <url>https://maven.aliyun.com/repository/public</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>

--- a/repository/src/main/java/com/novel/splitter/repository/api/JpaSceneRepository.java
+++ b/repository/src/main/java/com/novel/splitter/repository/api/JpaSceneRepository.java
@@ -7,16 +7,30 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Repository
 public interface JpaSceneRepository extends JpaRepository<JpaSceneEntity, Long> {
     
+    @Query("SELECT s.id as id, s.chapterIndex as chapterIndex, 'SCENE' as type, s.wordCount as tokenCount, SUBSTRING(s.text, 1, 150) as textContent FROM JpaSceneEntity s")
+    Page<com.novel.splitter.domain.model.dto.VectorPreviewRecordDto> findLightweightScenes(Pageable pageable);
+
     // Custom query method for SubTask 2.2: "按 ID 列表查询的方法"
     List<JpaSceneEntity> findByIdIn(List<Long> ids);
 
     List<JpaSceneEntity> findBySceneIdIn(List<String> sceneIds);
 
     List<JpaSceneEntity> findByNovelNameAndVersion(String novelName, String version);
+
+    Stream<JpaSceneEntity> streamAllByNovelNameAndVersion(String novelName, String version);
+
+    @Query("SELECT s FROM JpaSceneEntity s")
+    Stream<JpaSceneEntity> streamAll();
+
+    long countByNovelNameAndVersion(String novelName, String version);
 
     List<JpaSceneEntity> findByNovelName(String novelName);
 
@@ -30,4 +44,7 @@ public interface JpaSceneRepository extends JpaRepository<JpaSceneEntity, Long> 
 
     @Query("SELECT DISTINCT s.version FROM JpaSceneEntity s WHERE s.novelName = ?1")
     List<String> findDistinctVersionsByNovelName(String novelName);
+
+    @Query("SELECT s.novelName, s.version, COUNT(s) FROM JpaSceneEntity s GROUP BY s.novelName, s.version")
+    List<Object[]> countScenesByNovelAndVersion();
 }

--- a/repository/src/main/java/com/novel/splitter/repository/api/JpaSplitTaskRepository.java
+++ b/repository/src/main/java/com/novel/splitter/repository/api/JpaSplitTaskRepository.java
@@ -1,9 +1,12 @@
 package com.novel.splitter.repository.api;
 
 import com.novel.splitter.domain.entity.JpaSplitTaskEntity;
+import com.novel.splitter.domain.task.SplitTask.TaskStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaSplitTaskRepository extends JpaRepository<JpaSplitTaskEntity, String> {
+    long countByStatus(TaskStatus status);
+    long countByStatusAndUpdatedAtGreaterThanEqual(TaskStatus status, long timestamp);
 }


### PR DESCRIPTION
## 🎯 Changes

### 1. 系统设置与持久化管理
- 新增 `SystemSettingsController`，提供系统设置的获取和更新接口。
- 新增 `SystemSettingsService` 及其实现，支持将系统配置持久化到本地 JSON 文件。
- 新增 `SystemSettingsDto` 用于系统设置的数据传输。
- 补充 `SystemSettingsControllerTest` 和 `SystemSettingsServiceImplTest` 单元测试。

### 2. 任务与作业实时监控
- 新增 `JobController`，提供获取作业列表和作业统计信息的接口。
- `TaskService` 新增 `getJobStats` 和 `getAllJobs` 方法。
- 新增 `JobRecordDto` 和 `JobStatSummaryDto` 用于作业数据传输。
- `JpaSplitTaskRepository` 新增根据状态和更新时间统计任务数量的查询方法。

### 3. 文本切分效果内存预览
- 新增 `SplitPreviewController`，支持在内存中预览文本切分结果。
- 新增 `ChunkPreviewDto` 和 `SplitPreviewRequestDto` 用于切分预览的数据传输。

### 4. Chroma 向量数据库诊断与重建
- `ChromaManagementController` 新增 `/export` (流式导出数据)、`/diagnostics` (获取版本诊断信息) 和 `/collections/rebuild` (重建集合并清理本地数据库) 接口。
- `ChromaAdminService` 及其实现新增 `rebuildCollection` 和 `getVersionDiagnostics` 方法。
- 新增 `ChromaVersionDiagnosticDto` 用于 Chroma 版本诊断数据传输。

### 5. 知识库与小说统计功能增强
- `KnowledgeBaseController` 新增 `/scenes/lightweight` 接口，用于获取轻量级场景分页列表。
- `KnowledgeBaseService` 及其实现新增 `getLightweightScenes` 方法。
- `NovelController` 新增 `/stats` 接口，用于获取所有小说入库统计信息。
- `NovelFacadeService` 及其实现新增 `getNovelStats` 方法。
- 新增 `NovelStatRecordDto` 和 `VectorPreviewRecordDto` 用于数据传输。
- `JpaSceneRepository` 新增多个自定义 SQL 查询方法，支持轻量级场景分页和数据流查询。

### 6. Maven 仓库统一与依赖管理
- 统一 `application`, `embedding`, `llm-client` 模块及根 `pom.xml` 中的 Maven 仓库，将阿里云替换为 Apache 中央仓库。

## 💡 Technical Highlights

- **本地持久化**: 系统设置通过 JSON 文件在本地进行持久化，实现配置的离线存储和管理。
- **实时监控**: 通过新增的控制器和服务，实现了对切分任务和作业的实时状态查询和统计，提升了系统的可观测性。
- **内存预览**: 文本切分预览功能在内存中完成，避免了不必要的磁盘 I/O，提高了预览效率。
- **Chroma 管理**: 提供了 Chroma 数据库的诊断、数据导出和重建功能，增强了向量数据库的运维能力。
- **数据模型扩展**: 引入了多个 DTO 模型，为前端展示和后端数据传输提供了清晰的结构支持。
- **Maven 仓库统一**: 优化了项目依赖管理，统一使用 Apache 中央仓库，提高了构建的稳定性和可靠性。
