### PR TITLE
refactor: shift fine-grained chunking to initial splitting phase

### DIFF
--- a/application/src/main/java/com/novel/splitter/application/worker/SplitWorker.java
+++ b/application/src/main/java/com/novel/splitter/application/worker/SplitWorker.java
@@ -70,6 +70,9 @@ public class SplitWorker {
             
             if (message.getNovelId() != null) {
                 novelService.updateNovelStatus(message.getNovelId(), NovelStatus.SPLIT_COMPLETED);
+                // [FUTURE] 预留: 发送消息到 ENRICH_TASK_QUEUE 进行 AI 语义增强
+                // rabbitTemplate.convertAndSend(RabbitConfig.EXCHANGE_NAME, "enrich", new EnrichTaskMessage(taskId, message.getNovelId(), ...));
+                log.info("=== [AI Enrichment Placeholder] === Would trigger AI enrichment MQ task here for novel {}", message.getNovelId());
             }
             
             log.info("任务 {} Split 阶段完成，共处理 {} 个场景", taskId, sceneIds.size());

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -101,10 +101,12 @@ splitter:
   
   ingestion:
     batch-size: 10
+    chunk-size: 500
+    chunk-overlap: 100
     
   rule:
     target-length: 1200
-    min-length: 200
+    min-length: 50
     max-length: 3000
     ignore-empty-lines: true
     

--- a/domain/src/main/java/com/novel/splitter/domain/model/SceneMetadata.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/SceneMetadata.java
@@ -41,6 +41,9 @@ public class SceneMetadata {
     /** Chunk 类型 (e.g., "scene", "summary") */
     private String chunkType;
     
+    /** 序列号 (例如在切分后的片段序号) */
+    private Integer sequenceNum;
+    
     /** 角色/功能 (e.g., "narration", "dialogue") */
     private String role;
 

--- a/domain/src/main/java/com/novel/splitter/domain/strategy/OverlapChunkingStrategy.java
+++ b/domain/src/main/java/com/novel/splitter/domain/strategy/OverlapChunkingStrategy.java
@@ -44,16 +44,56 @@ public class OverlapChunkingStrategy implements ChunkingStrategy {
         int index = 0;
         int childIdx = 0;
         while (index < text.length()) {
-            int end = Math.min(index + chunkSize, text.length());
+            int maxEnd = Math.min(index + chunkSize, text.length());
+            int end = findBestSplitPoint(text, index, maxEnd);
+            
+            // If the chunk becomes too small due to lookback, just use maxEnd
+            if (end <= index) {
+                end = maxEnd;
+            }
+            
             String chunkText = text.substring(index, end);
             children.add(createChildScene(parent, chunkText, childIdx++));
 
             if (end == text.length()) {
                 break;
             }
+            // For overlap, also try to find a natural start if possible, but simple overlap is fine for now
             index = end - overlap;
         }
         return children;
+    }
+
+    private int findBestSplitPoint(String text, int start, int maxEnd) {
+        if (maxEnd >= text.length()) {
+            return text.length();
+        }
+        
+        // Try to find a good break point within the last 40% of the chunk
+        int lookbackLimit = Math.max(start + chunkSize / 2, maxEnd - (chunkSize * 4 / 10));
+        
+        // 1. Look for double newline
+        int doubleNewline = text.lastIndexOf("\n\n", maxEnd);
+        if (doubleNewline >= lookbackLimit) return doubleNewline + 2;
+        
+        // 2. Look for single newline
+        int singleNewline = text.lastIndexOf("\n", maxEnd);
+        if (singleNewline >= lookbackLimit) return singleNewline + 1;
+        
+        // 3. Look for major punctuation marks
+        for (int i = maxEnd - 1; i >= lookbackLimit; i--) {
+            char c = text.charAt(i);
+            if (c == '。' || c == '！' || c == '？' || c == '!' || c == '?') {
+                // include the closing quote if it's there
+                if (i + 1 < text.length() && (text.charAt(i + 1) == '”' || text.charAt(i + 1) == '"' || text.charAt(i + 1) == '’')) {
+                    return i + 2;
+                }
+                return i + 1;
+            }
+        }
+        
+        // Fallback to maxEnd
+        return maxEnd;
     }
 
     private Scene createChildScene(Scene parent, String text, int childIndex) {
@@ -75,6 +115,7 @@ public class OverlapChunkingStrategy implements ChunkingStrategy {
         }
         childMeta.setParentSceneId(parent.getId());
         childMeta.setChunkType("child_chunk");
+        childMeta.setSequenceNum(childIndex);
         child.setMetadata(childMeta);
 
         return child;

--- a/embedding/src/main/java/com/novel/splitter/embedding/store/ChromaVectorStore.java
+++ b/embedding/src/main/java/com/novel/splitter/embedding/store/ChromaVectorStore.java
@@ -87,7 +87,8 @@ public class ChromaVectorStore implements VectorStore {
                             
                             if (s.getMetadata() != null) {
                                 if (s.getMetadata().getNovel() != null) {
-                                    map.put("novel", s.getMetadata().getNovel());
+                                    map.put("novelId", s.getMetadata().getNovel());
+                                    map.put("novel", s.getMetadata().getNovel()); // Keep for backward compatibility
                                 }
                                 if (s.getMetadata().getVersion() != null) {
                                     map.put("version", s.getMetadata().getVersion());
@@ -97,6 +98,9 @@ public class ChromaVectorStore implements VectorStore {
                                 }
                                 if (s.getMetadata().getChunkType() != null) {
                                     map.put("chunk_type", s.getMetadata().getChunkType());
+                                }
+                                if (s.getMetadata().getSequenceNum() != null) {
+                                    map.put("sequenceNum", s.getMetadata().getSequenceNum());
                                 }
                             }
                             return map;

--- a/pipeline/src/main/java/com/novel/splitter/pipeline/orchestrator/EmbedNovelUseCase.java
+++ b/pipeline/src/main/java/com/novel/splitter/pipeline/orchestrator/EmbedNovelUseCase.java
@@ -1,14 +1,11 @@
 package com.novel.splitter.pipeline.orchestrator;
 
 import com.novel.splitter.domain.model.Scene;
-import com.novel.splitter.domain.strategy.ChunkingStrategy;
-import com.novel.splitter.domain.strategy.OverlapChunkingStrategy;
 import com.novel.splitter.embedding.api.EmbeddingService;
 import com.novel.splitter.embedding.api.VectorStore;
 import com.novel.splitter.repository.api.SceneRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -23,37 +20,26 @@ public class EmbedNovelUseCase {
     private final VectorStore vectorStore;
     private final SceneRepository sceneRepository;
 
-    @Value("${splitter.ingestion.chunk-size:150}")
-    private int chunkSize;
-
-    @Value("${splitter.ingestion.chunk-overlap:30}")
-    private int chunkOverlap;
-
     public void embedBatch(List<Long> sceneIds) {
         if (sceneIds == null || sceneIds.isEmpty()) return;
         List<Scene> scenes = sceneRepository.findByIds(sceneIds);
         if (scenes == null || scenes.isEmpty()) return;
 
-        ChunkingStrategy chunkingStrategy = new OverlapChunkingStrategy(chunkSize, chunkOverlap);
-
         try {
             List<String> texts = new ArrayList<>();
-            List<Scene> validChildScenes = new ArrayList<>();
+            List<Scene> validScenes = new ArrayList<>();
             for (Scene scene : scenes) {
                 if (scene.getText() != null && !scene.getText().trim().isEmpty()) {
-                    List<Scene> children = chunkingStrategy.split(scene);
-                    for (Scene child : children) {
-                        texts.add(child.getText());
-                        validChildScenes.add(child);
-                    }
+                    texts.add(scene.getText());
+                    validScenes.add(scene);
                 } else {
                     log.warn("Skipping scene ID {} due to empty text", scene.getId());
                 }
             }
-            if (validChildScenes.isEmpty()) return;
+            if (validScenes.isEmpty()) return;
 
             List<float[]> embeddings = embeddingService.embedBatch(texts);
-            vectorStore.saveBatch(validChildScenes, embeddings);
+            vectorStore.saveBatch(validScenes, embeddings);
         } catch (Exception e) {
             log.error("Error processing embed batch (Scene IDs: {}-...)", sceneIds.get(0), e);
             throw new RuntimeException("Batch embed processing failed", e);

--- a/pipeline/src/main/java/com/novel/splitter/pipeline/orchestrator/SplitNovelUseCase.java
+++ b/pipeline/src/main/java/com/novel/splitter/pipeline/orchestrator/SplitNovelUseCase.java
@@ -6,6 +6,8 @@ import com.novel.splitter.domain.model.Chapter;
 import com.novel.splitter.domain.model.ChapterData;
 import com.novel.splitter.domain.model.Novel;
 import com.novel.splitter.domain.model.Scene;
+import com.novel.splitter.domain.strategy.ChunkingStrategy;
+import com.novel.splitter.domain.strategy.OverlapChunkingStrategy;
 import com.novel.splitter.infrastructure.progress.IngestProgress;
 import com.novel.splitter.repository.api.SceneRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +29,14 @@ public class SplitNovelUseCase {
     
     private final SceneAssembler sceneAssembler = new SceneAssembler();
 
-    @Value("${splitter.rule.min-length:200}")
+    @Value("${splitter.rule.min-length:50}")
     private int minLength;
 
-    @Value("${splitter.rule.max-length:3000}")
-    private int maxLength;
+    @Value("${splitter.ingestion.chunk-size:500}")
+    private int chunkSize;
+
+    @Value("${splitter.ingestion.chunk-overlap:100}")
+    private int chunkOverlap;
 
     private List<Scene> filterByLength(List<Scene> scenes) {
         List<Scene> valid = new ArrayList<>();
@@ -41,10 +46,6 @@ public class SplitNovelUseCase {
                 log.warn("Scene {} (chapter {}) too short: {} chars, skipping",
                         s.getId(), s.getChapterTitle(), len);
                 continue;
-            }
-            if (len > maxLength) {
-                log.warn("Scene {} (chapter {}) too long: {} chars, will be chunked downstream",
-                        s.getId(), s.getChapterTitle(), len);
             }
             valid.add(s);
         }
@@ -63,6 +64,8 @@ public class SplitNovelUseCase {
             progressCallback.accept(IngestProgress.CHAPTER_END, String.format("准备逐章切分，共 %d 章", totalChapters));
         }
 
+        ChunkingStrategy chunkingStrategy = new OverlapChunkingStrategy(chunkSize, chunkOverlap);
+
         for (int i = 0; i < totalChapters; i++) {
             Chapter chapter = chapters.get(i);
             
@@ -70,8 +73,15 @@ public class SplitNovelUseCase {
             ChapterData chapterData = novelCacheService.loadChapter(taskId, chapter.getIndex());
             
             List<Scene> chapterScenes = sceneAssembler.assembleChapter(chapter, chapterData.getParagraphs(), novel.getTitle());
-            scenes.addAll(chapterScenes);
-            scenesCount += chapterScenes.size();
+            
+            // Apply fine-grained chunking immediately before DB save
+            List<Scene> chunkedScenes = new ArrayList<>();
+            for (Scene s : chapterScenes) {
+                chunkedScenes.addAll(chunkingStrategy.split(s));
+            }
+            
+            scenes.addAll(chunkedScenes);
+            scenesCount += chunkedScenes.size();
             
             if (progressCallback != null && (i % 10 == 0 || i == totalChapters - 1)) {
                 int progress = IngestProgress.calc(IngestProgress.SCENE_START, IngestProgress.SCENE_END, i + 1, totalChapters);


### PR DESCRIPTION
## 🎯 Changes

### 1. Fine-Grained Text Chunking
- Shifted chunking responsibility from embedding to initial splitting phase.
- Introduced intelligent boundary detection for natural text splits at punctuation or newlines.
- Added `sequenceNum` to `SceneMetadata` to track chunk order.

### 2. Application Configuration Updates
- Added `chunk size` and `overlap` configurations to `application.yml`.
- Reduced minimum scene length rule from 200 to 50 and removed maximum length limit.

### 3. Embedding and Pipeline Adjustments
- Removed on-the-fly chunking logic from `EmbedNovelUseCase`.
- Simplified embedding batch process to directly embed pre-chunked scenes.
- Integrated `OverlapChunkingStrategy` into `SplitNovelUseCase`.
- Updated `ChromaVectorStore` to include `sequenceNum` in metadata.

### 4. Future AI Enrichment Placeholder
- Added a placeholder and logging for future AI semantic enrichment messaging in `SplitWorker.java`.

## 💡 Technical Highlights

- **Improved Chunking Strategy**: Ensures natural and contextually relevant text splits.
- **Optimized Embedding Pipeline**: Reduces redundancy by performing chunking once, upstream.
- **Enhanced Metadata**: `sequenceNum` facilitates reassembly and ordered retrieval of text chunks.
- **Backward Compatibility**: Maintained `novel` field in `ChromaVectorStore` metadata while adding `novelId`.