### PR TITLE
feat: 引入文件MD5防重复上传与多版本章节支持

### DIFF
--- a/application/src/main/java/com/novel/splitter/application/service/novel/ChapterService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/ChapterService.java
@@ -20,4 +20,13 @@ public interface ChapterService {
      * @return 章节列表
      */
     List<Chapter> getChaptersByNovelId(String novelId);
+
+    /**
+     * 获取指定小说及版本的章节，按序号升序
+     *
+     * @param novelId 小说ID
+     * @param version 章节版本
+     * @return 章节列表
+     */
+    List<Chapter> getChaptersByNovelIdAndVersion(String novelId, String version);
 }

--- a/application/src/main/java/com/novel/splitter/application/service/novel/ChapterServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/ChapterServiceImpl.java
@@ -29,4 +29,9 @@ public class ChapterServiceImpl implements ChapterService {
     public List<Chapter> getChaptersByNovelId(String novelId) {
         return chapterRepository.findByNovelId(novelId);
     }
+
+    @Override
+    public List<Chapter> getChaptersByNovelIdAndVersion(String novelId, String version) {
+        return chapterRepository.findByNovelIdAndVersion(novelId, version);
+    }
 }

--- a/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeService.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeService.java
@@ -27,5 +27,7 @@ public interface NovelFacadeService {
 
     List<ChapterDto> getChapters(String novelId);
 
+    List<ChapterDto> getChapters(String novelId, String version);
+
     List<SceneDto> getScenesByChapter(String novelId, Long chapterId);
 }

--- a/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/NovelFacadeServiceImpl.java
@@ -228,12 +228,23 @@ public class NovelFacadeServiceImpl implements NovelFacadeService {
 
     @Override
     public List<com.novel.splitter.application.model.dto.ChapterDto> getChapters(String novelId) {
+        return getChapters(novelId, null);
+    }
+
+    @Override
+    public List<com.novel.splitter.application.model.dto.ChapterDto> getChapters(String novelId, String version) {
         com.novel.splitter.domain.model.Novel novel = novelService.getNovelById(novelId);
         if (novel == null) {
             throw new IllegalArgumentException("Novel not found: " + novelId);
         }
         novel.checkCanReadChapters();
-        return com.novel.splitter.application.mapper.DtoMapper.INSTANCE.toChapterDtos(chapterService.getChaptersByNovelId(novelId));
+        List<com.novel.splitter.domain.model.Chapter> chapters;
+        if (version == null || version.isEmpty()) {
+            chapters = chapterService.getChaptersByNovelId(novelId);
+        } else {
+            chapters = chapterService.getChaptersByNovelIdAndVersion(novelId, version);
+        }
+        return com.novel.splitter.application.mapper.DtoMapper.INSTANCE.toChapterDtos(chapters);
     }
 
     @Override

--- a/application/src/main/java/com/novel/splitter/application/service/novel/NovelServiceImpl.java
+++ b/application/src/main/java/com/novel/splitter/application/service/novel/NovelServiceImpl.java
@@ -8,9 +8,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.util.DigestUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -24,6 +26,15 @@ public class NovelServiceImpl implements NovelService {
     @Override
     @Transactional(rollbackFor = Exception.class)
     public String createNovel(MultipartFile file, String title, String author, String description) throws IOException {
+        String fileMd5 = DigestUtils.md5DigestAsHex(file.getInputStream());
+        long fileSize = file.getSize();
+
+        Optional<Novel> existingNovel = novelRepository.findByFileMd5(fileMd5);
+        if (existingNovel.isPresent()) {
+            log.info("File already exists with novelId: {}", existingNovel.get().getId());
+            return existingNovel.get().getId();
+        }
+
         String fileName = novelStorageService.saveNovel(file);
         
         String novelId = UUID.randomUUID().toString();
@@ -34,6 +45,8 @@ public class NovelServiceImpl implements NovelService {
                 .author(author)
                 .description(description)
                 .filePath(fileName)
+                .fileMd5(fileMd5)
+                .fileSize(fileSize)
                 .status(NovelStatus.PENDING)
                 .createdAt(System.currentTimeMillis())
                 .updatedAt(System.currentTimeMillis())

--- a/application/src/main/java/com/novel/splitter/application/worker/LoadWorker.java
+++ b/application/src/main/java/com/novel/splitter/application/worker/LoadWorker.java
@@ -69,6 +69,7 @@ public class LoadWorker {
                                 .novelId(novelEntity.getId())
                                 .title(chapter.getTitle())
                                 .index(chapter.getIndex())
+                                .version(task.getVersion())
                                 .wordCount(0) // Could be calculated if needed
                                 .build())
                         .collect(Collectors.toList());

--- a/batch-processing/src/main/java/com/novel/splitter/pipeline/orchestrator/EmbedNovelUseCase.java
+++ b/batch-processing/src/main/java/com/novel/splitter/pipeline/orchestrator/EmbedNovelUseCase.java
@@ -39,9 +39,25 @@ public class EmbedNovelUseCase {
             if (validScenes.isEmpty()) return;
 
             List<float[]> embeddings = embeddingService.embedBatch(texts);
-            vectorStore.saveBatch(validScenes, embeddings);
+            List<String> vectorIds = vectorStore.saveBatch(validScenes, embeddings);
+            
+            if (vectorIds != null && vectorIds.size() == validScenes.size()) {
+                for (int i = 0; i < validScenes.size(); i++) {
+                    Scene scene = validScenes.get(i);
+                    String vectorId = vectorIds.get(i);
+                    sceneRepository.updateEmbedStatus(Long.valueOf(scene.getId()), "SUCCESS", vectorId);
+                }
+            } else {
+                log.warn("Vector IDs returned do not match valid scenes count.");
+                for (Scene scene : validScenes) {
+                    sceneRepository.updateEmbedStatus(Long.valueOf(scene.getId()), "FAILED", null);
+                }
+            }
         } catch (Exception e) {
             log.error("Error processing embed batch (Scene IDs: {}-...)", sceneIds.get(0), e);
+            for (Long sceneId : sceneIds) {
+                sceneRepository.updateEmbedStatus(sceneId, "FAILED", null);
+            }
             throw new RuntimeException("Batch embed processing failed", e);
         }
     }

--- a/batch-processing/src/main/java/com/novel/splitter/pipeline/orchestrator/SplitNovelUseCase.java
+++ b/batch-processing/src/main/java/com/novel/splitter/pipeline/orchestrator/SplitNovelUseCase.java
@@ -80,8 +80,12 @@ public class SplitNovelUseCase {
                 chunkedScenes.addAll(chunkingStrategy.split(s));
             }
             
+            // Set absolute chunk index for ordering
+            for (Scene s : chunkedScenes) {
+                s.setChunkIndex(scenesCount++);
+            }
+            
             scenes.addAll(chunkedScenes);
-            scenesCount += chunkedScenes.size();
             
             if (progressCallback != null && (i % 10 == 0 || i == totalChapters - 1)) {
                 int progress = IngestProgress.calc(IngestProgress.SCENE_START, IngestProgress.SCENE_END, i + 1, totalChapters);

--- a/domain/src/main/java/com/novel/splitter/domain/model/Chapter.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/Chapter.java
@@ -23,6 +23,11 @@ public class Chapter {
     private String novelId;
 
     /**
+     * 章节版本
+     */
+    private String version;
+
+    /**
      * 章节序号，从 1 开始
      */
     private int index;

--- a/domain/src/main/java/com/novel/splitter/domain/model/Novel.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/Novel.java
@@ -27,6 +27,8 @@ public class Novel {
     private String description;
     private String coverUrl;
     private String filePath;
+    private String fileMd5;
+    private Long fileSize;
     private NovelStatus status;
     private long createdAt;
     private long updatedAt;

--- a/domain/src/main/java/com/novel/splitter/domain/model/Scene.java
+++ b/domain/src/main/java/com/novel/splitter/domain/model/Scene.java
@@ -33,6 +33,11 @@ public class Scene {
     private int chapterIndex;
 
     /**
+     * 片段绝对序号（全局排序用）
+     */
+    private int chunkIndex;
+
+    /**
      * 起始段落索引（全局 RawParagraph index）
      */
     private int startParagraphIndex;
@@ -68,6 +73,16 @@ public class Scene {
      * 元数据
      */
     private SceneMetadata metadata;
+
+    /**
+     * 向量化状态 (PENDING, SUCCESS, FAILED)
+     */
+    private String embedStatus = "PENDING";
+
+    /**
+     * 底层向量数据库对应的 Document ID
+     */
+    private String vectorId;
 
     /**
      * 检索评分 (非持久化字段，运行时注入)

--- a/domain/src/main/java/com/novel/splitter/domain/repository/ChapterRepository.java
+++ b/domain/src/main/java/com/novel/splitter/domain/repository/ChapterRepository.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface ChapterRepository {
     void saveAll(List<Chapter> chapters);
+    List<Chapter> findByNovelIdAndVersion(String novelId, String version);
     List<Chapter> findByNovelId(String novelId);
 }

--- a/domain/src/main/java/com/novel/splitter/domain/repository/NovelRepository.java
+++ b/domain/src/main/java/com/novel/splitter/domain/repository/NovelRepository.java
@@ -21,6 +21,11 @@ public interface NovelRepository {
     Optional<Novel> findById(String id);
 
     /**
+     * 根据文件 MD5 查找小说
+     */
+    Optional<Novel> findByFileMd5(String fileMd5);
+
+    /**
      * 列出所有小说
      */
     List<Novel> findAll();

--- a/domain/src/main/java/com/novel/splitter/domain/repository/SceneRepository.java
+++ b/domain/src/main/java/com/novel/splitter/domain/repository/SceneRepository.java
@@ -105,8 +105,19 @@ public interface SceneRepository {
      */
     List<Scene> findByNovelIdAndChapterId(String novelId, Long chapterId);
     /**
-     * 统计所有小说和版本下的场景数量，返回格式为 Object[] {novelName, version, count}
-     * @return 统计结果列表
+     * 根据小说 ID 和向量化状态获取场景
+     * @param novelId 小说 ID
+     * @param embedStatus 向量化状态 (PENDING, SUCCESS, FAILED)
+     * @return 场景列表
      */
+    List<Scene> findByNovelIdAndEmbedStatus(String novelId, String embedStatus);
+
+    /**
+     * 更新场景的向量化状态和文档ID
+     * @param sceneId 场景内部自增 ID
+     * @param embedStatus 向量化状态
+     * @param vectorId 向量库 Document ID
+     */
+    void updateEmbedStatus(Long sceneId, String embedStatus, String vectorId);
     List<Object[]> countScenesByNovelAndVersion();
 }

--- a/embedding/src/main/java/com/novel/splitter/embedding/api/VectorStore.java
+++ b/embedding/src/main/java/com/novel/splitter/embedding/api/VectorStore.java
@@ -18,13 +18,15 @@ public interface VectorStore {
      *
      * @param scene     场景对象
      * @param embedding 对应的向量
+     * @return 向量库中生成的 Document ID
      */
-    void save(Scene scene, float[] embedding);
+    String save(Scene scene, float[] embedding);
 
     /**
      * 批量保存
+     * @return 向量库中生成的 Document ID 列表，顺序与 scenes 一致
      */
-    void saveBatch(List<Scene> scenes, List<float[]> embeddings);
+    List<String> saveBatch(List<Scene> scenes, List<float[]> embeddings);
 
     /**
      * 相似度检索 (Semantic Search)

--- a/embedding/src/main/java/com/novel/splitter/embedding/mock/MockVectorStore.java
+++ b/embedding/src/main/java/com/novel/splitter/embedding/mock/MockVectorStore.java
@@ -54,21 +54,24 @@ public class MockVectorStore implements VectorStore {
     }
 
     @Override
-    public void save(Scene scene, float[] embedding) {
+    public String save(Scene scene, float[] embedding) {
         log.debug("Mock saving scene: {} (Vector dim: {})", scene.getId(), embedding.length);
         index.put(scene.getId(), embedding);
         if (scene.getMetadata() != null) {
             metadataMap.put(scene.getId(), scene.getMetadata());
         }
         ids.add(scene.getId());
+        return scene.getId();
     }
 
     @Override
-    public void saveBatch(List<Scene> scenes, List<float[]> embeddings) {
+    public List<String> saveBatch(List<Scene> scenes, List<float[]> embeddings) {
         log.info("Mock saving batch of {} scenes", scenes.size());
+        List<String> savedIds = new ArrayList<>(scenes.size());
         for (int i = 0; i < scenes.size(); i++) {
-            save(scenes.get(i), embeddings.get(i));
+            savedIds.add(save(scenes.get(i), embeddings.get(i)));
         }
+        return savedIds;
     }
 
     @Override

--- a/embedding/src/main/java/com/novel/splitter/embedding/store/ChromaVectorStore.java
+++ b/embedding/src/main/java/com/novel/splitter/embedding/store/ChromaVectorStore.java
@@ -61,8 +61,9 @@ public class ChromaVectorStore implements VectorStore {
     }
 
     @Override
-    public void save(Scene scene, float[] embedding) {
-        saveBatch(Collections.singletonList(scene), Collections.singletonList(embedding));
+    public String save(Scene scene, float[] embedding) {
+        List<String> ids = saveBatch(Collections.singletonList(scene), Collections.singletonList(embedding));
+        return ids != null && !ids.isEmpty() ? ids.get(0) : null;
     }
 
     /**
@@ -70,12 +71,13 @@ public class ChromaVectorStore implements VectorStore {
      *
      * @param scenes     场景对象列表
      * @param embeddings 对应的向量列表
+     * @return 向量库中生成的 Document ID 列表，顺序与 scenes 一致
      */
     @Override
-    public void saveBatch(List<Scene> scenes, List<float[]> embeddings) {
+    public List<String> saveBatch(List<Scene> scenes, List<float[]> embeddings) {
         ensureCollectionExists();
 
-        if (scenes.isEmpty()) return;
+        if (scenes.isEmpty()) return Collections.emptyList();
 
         List<String> ids = scenes.stream().map(Scene::getId).collect(Collectors.toList());
         List<Map<String, Object>> metadatas = scenes.stream()
@@ -130,6 +132,7 @@ public class ChromaVectorStore implements VectorStore {
                 .toBodilessEntity();
         
         log.info("Saved {} vectors to ChromaDB collection '{}'", scenes.size(), collectionName);
+        return ids;
     }
 
     /**

--- a/embedding/src/main/java/com/novel/splitter/embedding/store/InMemoryVectorStore.java
+++ b/embedding/src/main/java/com/novel/splitter/embedding/store/InMemoryVectorStore.java
@@ -130,25 +130,28 @@ public class InMemoryVectorStore implements VectorStore {
     }
 
     @Override
-    public void save(Scene scene, float[] embedding) {
+    public String save(Scene scene, float[] embedding) {
         if (scene == null || scene.getId() == null) {
             log.warn("Cannot save null scene or scene with null ID");
-            return;
+            return null;
         }
         vectorMap.put(scene.getId(), embedding);
         if (scene.getMetadata() != null) {
             metadataMap.put(scene.getId(), scene.getMetadata());
         }
+        return scene.getId();
     }
 
     @Override
-    public void saveBatch(List<Scene> scenes, List<float[]> embeddings) {
+    public List<String> saveBatch(List<Scene> scenes, List<float[]> embeddings) {
         if (scenes.size() != embeddings.size()) {
             throw new IllegalArgumentException("Scenes and embeddings size mismatch");
         }
+        List<String> ids = new ArrayList<>(scenes.size());
         for (int i = 0; i < scenes.size(); i++) {
-            save(scenes.get(i), embeddings.get(i));
+            ids.add(save(scenes.get(i), embeddings.get(i)));
         }
+        return ids;
     }
 
     @Override

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaChapterEntity.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaChapterEntity.java
@@ -24,6 +24,10 @@ public class JpaChapterEntity {
     @JoinColumn(name = "novel_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
     private JpaNovelEntity novel;
 
+    @Column(name = "version", nullable = false)
+    @Builder.Default
+    private String version = "v1";
+
     @Column(name = "title", nullable = false)
     private String title;
 

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaNovelEntity.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaNovelEntity.java
@@ -36,6 +36,12 @@ public class JpaNovelEntity {
     @Column(name = "file_path")
     private String filePath;
 
+    @Column(name = "file_md5", length = 64)
+    private String fileMd5;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private NovelStatus status;

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaSceneEntity.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/entity/JpaSceneEntity.java
@@ -44,6 +44,9 @@ public class JpaSceneEntity {
     @Column(name = "chapter_index")
     private int chapterIndex;
 
+    @Column(name = "chunk_index")
+    private int chunkIndex;
+
     @Column(name = "start_paragraph_index")
     private int startParagraphIndex;
 
@@ -65,6 +68,13 @@ public class JpaSceneEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "metadata_json", columnDefinition = "jsonb")
     private String metadataJson;
+
+    @Column(name = "embed_status")
+    @Builder.Default
+    private String embedStatus = "PENDING";
+
+    @Column(name = "vector_id")
+    private String vectorId;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaChapterRepository.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaChapterRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface JpaChapterRepository extends JpaRepository<JpaChapterEntity, Long> {
     List<JpaChapterEntity> findByNovelIdOrderByIndexNumAsc(String novelId);
+    List<JpaChapterEntity> findByNovelIdAndVersionOrderByIndexNumAsc(String novelId, String version);
 }

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaNovelRepository.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaNovelRepository.java
@@ -4,6 +4,9 @@ import com.novel.splitter.infrastructure.persistence.entity.JpaNovelEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface JpaNovelRepository extends JpaRepository<JpaNovelEntity, String> {
+    Optional<JpaNovelEntity> findByFileMd5(String fileMd5);
 }

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaSceneRepository.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/JpaSceneRepository.java
@@ -24,6 +24,8 @@ public interface JpaSceneRepository extends JpaRepository<JpaSceneEntity, Long>,
     List<JpaSceneEntity> findBySceneIdIn(List<String> sceneIds);
 
     List<JpaSceneEntity> findByNovelNameAndVersion(String novelName, String version);
+    
+    List<JpaSceneEntity> findByNovelIdAndEmbedStatus(String novelId, String embedStatus);
 
     Page<JpaSceneEntity> findByNovelId(String novelId, Pageable pageable);
 

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/ChapterRepositoryJpaImpl.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/ChapterRepositoryJpaImpl.java
@@ -46,4 +46,12 @@ public class ChapterRepositoryJpaImpl implements ChapterRepository {
                 .map(chapterMapper::toDomain)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<Chapter> findByNovelIdAndVersion(String novelId, String version) {
+        return jpaChapterRepository.findByNovelIdAndVersionOrderByIndexNumAsc(novelId, version)
+                .stream()
+                .map(chapterMapper::toDomain)
+                .collect(Collectors.toList());
+    }
 }

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/NovelRepositoryJpaImpl.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/NovelRepositoryJpaImpl.java
@@ -37,6 +37,11 @@ public class NovelRepositoryJpaImpl implements NovelRepository {
     }
 
     @Override
+    public Optional<Novel> findByFileMd5(String fileMd5) {
+        return jpaNovelRepository.findByFileMd5(fileMd5).map(novelMapper::toDomain);
+    }
+
+    @Override
     public List<Novel> findAll() {
         return jpaNovelRepository.findAll().stream()
                 .map(novelMapper::toDomain)

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/SceneRepositoryJpaImpl.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/SceneRepositoryJpaImpl.java
@@ -40,7 +40,7 @@ public class SceneRepositoryJpaImpl implements SceneRepository {
 
         if (novelId != null && !novelId.isEmpty()) {
             novelEntity = jpaNovelRepository.findById(novelId).orElse(null);
-            List<JpaChapterEntity> chapterEntities = jpaChapterRepository.findByNovelIdOrderByIndexNumAsc(novelId);
+            List<JpaChapterEntity> chapterEntities = jpaChapterRepository.findByNovelIdAndVersionOrderByIndexNumAsc(novelId, version);
             if (chapterEntities != null) {
                 for (JpaChapterEntity c : chapterEntities) {
                     chapterMap.put(c.getIndexNum(), c);

--- a/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/SceneRepositoryJpaImpl.java
+++ b/infrastructure/src/main/java/com/novel/splitter/infrastructure/persistence/repository/impl/SceneRepositoryJpaImpl.java
@@ -159,11 +159,28 @@ public class SceneRepositoryJpaImpl implements SceneRepository {
     @Override
     public List<Scene> findByNovelIdAndChapterId(String novelId, Long chapterId) {
         return jpaSceneRepository.findAll((root, query, cb) -> {
+            query.orderBy(cb.asc(root.get("chunkIndex")));
             return cb.and(
                 cb.equal(root.get("novel").get("id"), novelId),
                 cb.equal(root.get("chapter").get("id"), chapterId)
             );
         }).stream().map(sceneMapper::toDomain).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Scene> findByNovelIdAndEmbedStatus(String novelId, String embedStatus) {
+        List<JpaSceneEntity> entities = jpaSceneRepository.findByNovelIdAndEmbedStatus(novelId, embedStatus);
+        return entities.stream().map(sceneMapper::toDomain).collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void updateEmbedStatus(Long sceneId, String embedStatus, String vectorId) {
+        jpaSceneRepository.findById(sceneId).ifPresent(entity -> {
+            entity.setEmbedStatus(embedStatus);
+            entity.setVectorId(vectorId);
+            jpaSceneRepository.save(entity);
+        });
     }
 
     @Override

--- a/interfaces/src/main/java/com/novel/splitter/interfaces/api/NovelController.java
+++ b/interfaces/src/main/java/com/novel/splitter/interfaces/api/NovelController.java
@@ -65,8 +65,8 @@ public class NovelController {
      */
     @Operation(summary = "获取小说章节树", description = "获取小说的所有章节层级结构")
     @GetMapping("/{novelId}/chapters")
-    public List<ChapterDto> getChapters(@PathVariable String novelId) {
-        return novelFacadeService.getChapters(novelId);
+    public List<ChapterDto> getChapters(@PathVariable String novelId, @RequestParam(required = false) String version) {
+        return novelFacadeService.getChapters(novelId, version);
     }
 
     @Operation(summary = "获取章节片段", description = "获取某章节下的所有切分片段 (Scenes)")


### PR DESCRIPTION
## 🎯 Changes

### 1. 文件MD5防重复上传机制
- 在小说上传服务中增加文件MD5校验，防止重复上传。
- 小说实体（`Novel`）新增 `fileMd5` 和 `fileSize` 属性，用于持久化文件信息。
- 新增 `NovelRepository` 接口方法和JPA实现，支持按MD5查询小说。

### 2. 多版本章节数据流转与查询支持
- 章节实体（`Chapter`）新增 `version` 属性，支持章节多版本管理。
- `ChapterService` 和 `NovelFacadeService` 增加按小说ID和版本查询章节列表的接口和实现。
- `ChapterRepository` 及其JPA实现新增按小说ID和版本查询的方法。
- `LoadWorker` 在构建章节数据时，从加载任务中读取并设置章节版本信息。
- `NovelController` 修改获取章节树接口，支持接收可选的 `version` 查询参数。

### 3. 增强底层向量化处理流程
- 场景实体（`Scene`）新增 `chunkIndex` 用于全局排序，`embedStatus` 和 `vectorId` 用于记录向量化状态及关联文档ID。
- `SplitNovelUseCase` 在切分小说场景时为每个片段设置绝对排序索引。
- `EmbedNovelUseCase` 调整向量批量保存逻辑，接收并处理向量库返回的文档ID列表，并更新场景的向量化状态和文档ID。
- `VectorStore` 接口及其实现（`MockVectorStore`, `ChromaVectorStore`, `InMemoryVectorStore`）修改，支持返回保存后的文档ID。
- `SceneRepository` 及其JPA实现新增按向量化状态查询场景以及更新场景向量化状态和文档ID的方法。

## 💡 Technical Highlights

- **防重复上传**: 通过文件MD5校验，有效避免了相同内容的重复上传，提升了数据完整性和系统效率。
- **多版本支持**: 引入章节版本机制，为未来可能的小说内容迭代和版本管理提供了基础架构支持。
- **向量化流程优化**: 记录场景的全局排序索引和持久化向量ID，显著提升了向量化处理的可靠性和数据同步的准确性，为后续的向量检索和更新奠定了基础。
- **领域模型扩展**: 核心领域模型（`Novel`, `Chapter`, `Scene`）的扩展，使其能够承载更丰富的数据和状态信息，支持新功能的实现。